### PR TITLE
fix: explicitly reference tn-aixpa/dt-model

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,7 +3,8 @@
 ## Overview
 
 YAKOF is a technology demonstrator showing how we could evolve the existing
-dt-model package. The key improvements demonstrated are:
+[dt-model](https://github.com/tn-aixpa/dt-model) package. The key improvements
+demonstrated are:
 
 1. Replacement of SymPy with a focused AST framework
 2. Type-safe parameter space modeling

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 ![Yes, it's literally a kettle of fish!](yakof.png)
 
-YAKOF demonstrates improved typing and tensor manipulation for sustainability modeling.
-See [DESIGN.md](DESIGN.md) for the detailed architecture and rationale.
+YAKOF demonstrates improved typing and tensor manipulation for sustainability modeling,
+and specifically for the [Fondazione Bruno Kessler's](https://fbk.eu) [DT Model](
+https://github.com/tn-aixpa/dt-model) model. See [DESIGN.md](DESIGN.md) for the detailed
+architecture and rationale.
 
 ## Quick Start
 


### PR DESCRIPTION
Make sure we explicitly reference the original model we used as the starting point.