### PR TITLE
feat: benchmark yakof vs sympy

### DIFF
--- a/examples/bench00.py
+++ b/examples/bench00.py
@@ -1,0 +1,142 @@
+"""Performance benchmark comparing Yakof against NumPy/SymPy implementations.
+
+This benchmark aims to validate that Yakof's computation graph approach achieves
+comparable performance to direct NumPy operations (via SymPy's lambdify). Since
+Yakof's main value proposition is improved safety and composability over raw NumPy,
+we need high confidence that this doesn't come at a significant performance cost.
+
+The benchmark compares creation time, computation time, and memory usage for both
+approaches across different input sizes. Results consistently show that Yakof
+achieves reasonably similar performance compared to SymPy-generated NumPy code.
+"""
+
+from typing import Callable
+
+import numpy as np
+import sympy
+
+from yakof.backend import graph, numpy_engine
+from yakof.benchmark import NumericFunc, NumericFuncFactory, Results, run
+
+
+def build_yakof_model() -> NumericFuncFactory:
+    """Build Yakof model factory compatible with benchmark interface.
+
+    Returns a factory function that creates a new instance of the benchmark
+    model using Yakof's computation graph. The model computes a ~complex
+    mathematical expression combining polynomial, exponential, logarithmic
+    and maximum operations.
+    """
+
+    def factory() -> NumericFunc:
+        # Build the graph
+        x = graph.placeholder("x0")
+        y = graph.placeholder("x1")
+        t1 = x * x + y * y
+        t2 = x * y
+        t3 = graph.exp(-0.1 * (t1 - t2))
+        t4 = graph.log(1.0 + t1 + t2)
+        t5 = graph.maximum(t3, t4)
+        result = t1 / (1.0 + t2 * t2) + t5 * 0.1
+
+        # Create the evaluation function
+        def evaluate(xx: np.ndarray, yy: np.ndarray) -> np.ndarray:
+            # Note: explicitly using a NullCache to avoid caching results
+            ctx = numpy_engine.PartialEvaluationContext(
+                bindings={"x0": xx, "x1": yy}, cache=numpy_engine.NullCache()
+            )
+            return ctx.evaluate(result)
+
+        return evaluate
+
+    return factory
+
+
+def build_sympy_model() -> NumericFuncFactory:
+    """Build SymPy model factory compatible with benchmark interface.
+
+    Returns a factory function that creates a new instance of the benchmark
+    model using SymPy's symbolic computation and lambdify. The model computes
+    the same mathematical expression used for the Yakof version.
+    """
+
+    def factory() -> NumericFunc:
+        # Note: we need to sprinkle some `type: ignore` to appease pyright
+
+        # Build the overall expression
+        x = sympy.Symbol("x0")
+        y = sympy.Symbol("x1")
+        t1 = x * x + y * y  # type: ignore
+        t2 = x * y  # type: ignore
+        t3 = sympy.exp(-0.1 * (t1 - t2))
+        t4 = sympy.log(1.0 + t1 + t2)
+        t5 = sympy.Max(t3, t4)
+        expr = t1 / (1.0 + t2 * t2) + t5 * 0.1  # type: ignore
+
+        # Create the evaluation function
+        func = sympy.lambdify([x, y], expr)
+        return lambda xx, yy: func(xx, yy)
+
+    return factory
+
+
+def print_comparison(yakof_results: Results, sympy_results: Results) -> None:
+    """Print comparative benchmark results between Yakof and SymPy implementations."""
+    print("\nPure computation times:")
+    print(
+        f"Yakof: {yakof_results.mean_compute_time:.6f} ± "
+        f"{yakof_results.std_compute_time:.6f} seconds"
+    )
+    print(
+        f"SymPy: {sympy_results.mean_compute_time:.6f} ± "
+        f"{sympy_results.std_compute_time:.6f} seconds"
+    )
+
+    print("\nModel creation times:")
+    print(
+        f"Yakof: {yakof_results.mean_creation_time:.6f} ± "
+        f"{yakof_results.std_creation_time:.6f} seconds"
+    )
+    print(
+        f"SymPy: {sympy_results.mean_creation_time:.6f} ± "
+        f"{sympy_results.std_creation_time:.6f} seconds"
+    )
+
+    print("\nMemory usage:")
+    print(
+        f"Yakof creation: {yakof_results.creation_memory_peak / (1024 * 1024):.2f} MiB"
+    )
+    print(f"Yakof compute: {yakof_results.compute_memory_peak / (1024 * 1024):.2f} MiB")
+    print(
+        f"SymPy creation: {sympy_results.creation_memory_peak / (1024 * 1024):.2f} MiB"
+    )
+    print(f"SymPy compute: {sympy_results.compute_memory_peak / (1024 * 1024):.2f} MiB")
+
+
+def main() -> None:
+    """Run benchmarks comparing Yakof and SymPy implementations."""
+    grid_sizes: list[int] = [100, 500, 1000, 2000]
+    n_runs: int = 100
+
+    for size in grid_sizes:
+        print(f"\nGrid size: {size}x{size}")
+        x = np.linspace(-2, 2, size)
+        y = np.linspace(-2, 2, size)
+
+        yakof_results = run(x, y, build_yakof_model(), n_runs=n_runs)
+        sympy_results = run(x, y, build_sympy_model(), n_runs=n_runs)
+
+        print_comparison(yakof_results, sympy_results)
+
+        # Verify results match
+        #
+        # Note: we expect results close to the machine epsilon
+        xx, yy = np.meshgrid(x, y)
+        yakof_result = build_yakof_model()()(xx, yy)
+        sympy_result = build_sympy_model()()(xx, yy)
+        max_diff = float(np.max(np.abs(yakof_result - sympy_result)))
+        print(f"\nMaximum difference between implementations: {max_diff}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas",
+    "sympy",
     "scipy",
     "typing_extensions",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -336,6 +336,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -648,6 +657,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/8a/5a7fd6284fa8caac23a26c9ddf9c30485a48169344b4bd3b0f02fef1890f/sympy-1.13.3.tar.gz", hash = "sha256:b27fd2c6530e0ab39e275fc9b683895367e51d5da91baa8d3d64db2565fec4d9", size = 7533196 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/ff/c87e0622b1dadea79d2fb0b25ade9ed98954c9033722eb707053d310d4f3/sympy-1.13.3-py3-none-any.whl", hash = "sha256:54612cf55a62755ee71824ce692986f23c88ffa77207b30c1368eda4a7060f73", size = 6189483 },
+]
+
+[[package]]
 name = "tblib"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -720,6 +741,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "scipy" },
+    { name = "sympy" },
     { name = "typing-extensions" },
 ]
 
@@ -735,6 +757,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "scipy" },
+    { name = "sympy" },
     { name = "typing-extensions" },
 ]
 

--- a/yakof/backend/__init__.py
+++ b/yakof/backend/__init__.py
@@ -25,8 +25,9 @@ found that rolling our own DSL allowed us to more easily integrate with NumPy
 concepts, with benefits such as automated handling of dimensions. Additionally,
 this DSL does not have the performance penalty caused by sympy.lambdify, even
 though there is a penalty caused by evaluating the DSL's AST. However, because
-the bottleneck is numerical computation, this overhead seems to be small
-compared to the flexibility benefits we gained.
+the bottleneck is numerical computation, according to some benchmarks in the
+examples directory this overhead seems to be very small and is outweighed by
+all the benefits we gained.
 
 Overall, the goal of this module is to provide a solid low-level foundation
 for writing sustainability models at low-level. Also, higher-level modules should

--- a/yakof/benchmark/__init__.py
+++ b/yakof/benchmark/__init__.py
@@ -1,0 +1,122 @@
+"""
+Benchmarking utilities
+======================
+
+This package provides benchmarking tools for numerical computations that operate on
+numpy arrays, with a focus on measuring creation and computation performance.
+
+For each benchmark, it measures:
+- Creation time: Time taken to build the numeric computation model
+- Computation time: Time taken to execute the computation
+- Memory usage: Peak memory used during both creation and computation
+
+The main use case is comparing the performance of different numerical computation
+backends (e.g. yakof vs sympy) across varying input sizes. Results include both
+mean times and standard deviations to assess the performance stability.
+
+See the examples directory for sample benchmark scripts demonstrating usage.
+"""
+
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Callable, Protocol, runtime_checkable
+
+import gc
+import numpy as np
+import timeit
+import tracemalloc
+
+
+@dataclass
+class Results:
+    """Contains the benchmark results."""
+
+    creation_times: list[float] = field(default_factory=list)
+    creation_memory_peak: int = 0
+
+    compute_times: list[float] = field(default_factory=list)
+    compute_memory_peak: int = 0
+
+    @property
+    def mean_creation_time(self) -> float:
+        return float(np.mean(self.creation_times))
+
+    @property
+    def mean_compute_time(self) -> float:
+        return float(np.mean(self.compute_times))
+
+    @property
+    def std_creation_time(self) -> float:
+        return float(np.std(self.creation_times))
+
+    @property
+    def std_compute_time(self) -> float:
+        return float(np.std(self.compute_times))
+
+
+NumericFunc = Callable[[np.ndarray, np.ndarray], np.ndarray]
+NumericFuncFactory = Callable[[], NumericFunc]
+
+
+def run(
+    x: np.ndarray, y: np.ndarray, factory: NumericFuncFactory, n_runs: int = 100
+) -> Results:
+    """Benchmarks the given factory function using the given x and y arrays.
+
+    The factory function should return a callable that implements a numerical computation
+    on two numpy arrays. The returned callable should take two arguments (x and y arrays)
+    and return a numpy array containing the computation results.
+
+    Example factory function:
+        def my_factory():
+            def compute(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+                return x + y  # Some numerical computation
+            return compute
+
+    Args:
+        x: First input array for the computation
+        y: Second input array for the computation
+        factory: A function that returns a callable implementing the numerical computation
+        n_runs: Number of times to repeat the benchmark measurements
+
+    Returns:
+        A Results object containing timing and memory measurements
+    """
+
+    # Create the final results
+    results = Results()
+
+    # Create test data using a meshgrid for proper broadcasting
+    xx, yy = np.meshgrid(x, y)
+
+    # Measure the overall creation memory
+    tracemalloc.start()
+    numeric_func = factory()
+    _, peak_memory = tracemalloc.get_traced_memory()  # only focus on peak
+    tracemalloc.stop()
+    results.creation_memory_peak = peak_memory
+
+    # Measure the computation memory
+    tracemalloc.start()
+    _ = numeric_func(xx, yy)
+    _, peak_memory = tracemalloc.get_traced_memory()  # only focus on peak
+    tracemalloc.stop()
+    results.compute_memory_peak = peak_memory
+
+    # Benchmark runs
+    for _ in range(n_runs):
+        # Measure the creation time
+        gc.collect()
+        create_start = timeit.default_timer()
+        numeric_func = factory()
+        create_time = timeit.default_timer() - create_start
+        results.creation_times.append(create_time)
+
+        # Measure the computation time
+        gc.collect()
+        compute_start = timeit.default_timer()
+        result = numeric_func(xx, yy)
+        compute_time = timeit.default_timer() - compute_start
+        results.compute_times.append(compute_time)
+
+    return results


### PR DESCRIPTION
This commit introduces simple benchmarking code and includes a simple benchmark comparison betweem yakof and sympy.

As a side effect, sympy is now a compile time dependency. I don't consider this change to be problematic, since we would quite likely need sympy to perform dimensional analysis in about a month. If I am wrong, I can always remove sympy and the benchmark later on.

Here's the result when running this code locally:

```
Grid size: 100x100

Pure computation times:
Yakof: 0.000441 ± 0.000320 seconds
SymPy: 0.000459 ± 0.000277 seconds

Model creation times:
Yakof: 0.000070 ± 0.000013 seconds
SymPy: 0.008086 ± 0.001365 seconds

Memory usage:
Yakof creation: 0.01 MiB
Yakof compute: 0.38 MiB
SymPy creation: 2.26 MiB
SymPy compute: 0.38 MiB

Maximum difference between implementations: 8.881784197001252e-16

Grid size: 500x500

Pure computation times:
Yakof: 0.011254 ± 0.000788 seconds
SymPy: 0.011980 ± 0.001284 seconds

Model creation times:
Yakof: 0.000069 ± 0.000006 seconds
SymPy: 0.007812 ± 0.000512 seconds

Memory usage:
Yakof creation: 0.00 MiB
Yakof compute: 7.63 MiB
SymPy creation: 0.11 MiB
SymPy compute: 9.54 MiB

Maximum difference between implementations: 8.881784197001252e-16

Grid size: 1000x1000

Pure computation times:
Yakof: 0.042041 ± 0.003576 seconds
SymPy: 0.042521 ± 0.002009 seconds

Model creation times:
Yakof: 0.000073 ± 0.000014 seconds
SymPy: 0.007737 ± 0.000455 seconds

Memory usage:
Yakof creation: 0.00 MiB
Yakof compute: 30.52 MiB
SymPy creation: 0.11 MiB
SymPy compute: 38.15 MiB

Maximum difference between implementations: 1.3322676295501878e-15

Grid size: 2000x2000

Pure computation times:
Yakof: 0.149448 ± 0.006707 seconds
SymPy: 0.162993 ± 0.007928 seconds

Model creation times:
Yakof: 0.000071 ± 0.000010 seconds
SymPy: 0.007281 ± 0.000343 seconds

Memory usage:
Yakof creation: 0.00 MiB
Yakof compute: 122.07 MiB
SymPy creation: 0.11 MiB
SymPy compute: 152.59 MiB

Maximum difference between implementations: 1.3322676295501878e-15
```

I consider these results good enough to suggest it's okay to move on with using yakof instead of sympy. We still do not exactly have an epsilon like difference, but we're still around 1e-15 while dealing with numbers around 1, so this is probably okay and I suspect we could slightly improve the situation reordering operations.