### PR TITLE
feat: start sketching out yakof.frontend.graph

### DIFF
--- a/tests/frontend/__init__.py
+++ b/tests/frontend/__init__.py
@@ -1,0 +1,5 @@
+"""
+Tests for the yakof.frontend package.
+"""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/frontend/test_graph.py
+++ b/tests/frontend/test_graph.py
@@ -1,0 +1,174 @@
+"""Tests for the yakof.frontend.graph module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from yakof.frontend import graph
+
+
+def test_basic_node_creation():
+    """Test basic node creation and properties."""
+    # Test constants
+    c1 = graph.constant(1.0, name="c1")
+    assert c1.value == 1.0
+    assert c1.name == "c1"
+
+    # Test placeholders
+    p1 = graph.placeholder("x", 1.0)
+    assert p1.name == "x"
+    assert p1.default_value == 1.0
+
+    p2 = graph.placeholder("y")
+    assert p2.name == "y"
+    assert p2.default_value is None
+
+
+def test_node_identity():
+    """Test that nodes maintain proper identity."""
+    a = graph.constant(1.0)
+    b = graph.constant(1.0)
+    assert hash(a) != hash(b)
+    assert a is not b
+
+    # Test identity preservation in operations
+    c = graph.add(a, b)
+    assert c.left is a
+    assert c.right is b
+
+
+def test_debug_flags():
+    """Test debug operation flags."""
+    a = graph.constant(1.0)
+
+    # Test tracepoint
+    traced = graph.tracepoint(a)
+    assert traced.flags & graph.NODE_FLAG_TRACE
+    assert traced is a  # Should return same node
+
+    # Test breakpoint
+    broken = graph.breakpoint(a)
+    assert broken.flags & graph.NODE_FLAG_BREAK
+    assert broken.flags & graph.NODE_FLAG_TRACE
+    assert broken is a  # Should return same node
+
+
+def test_complex_arithmetic_graph():
+    """Test building a complex arithmetic computation graph."""
+    # Build ((a + b) * c)^2 + exp(d)
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+    c = graph.placeholder("c")
+    d = graph.placeholder("d")
+
+    add_ab = graph.add(a, b)
+    mult_c = graph.multiply(add_ab, c)
+    square = graph.power(mult_c, graph.constant(2.0))
+    exp_d = graph.exp(d)
+    result = graph.add(square, exp_d)
+
+    # Verify structure
+    assert result.left is square
+    assert result.right is exp_d
+    assert square.left is mult_c
+    assert square.right.value == 2.0
+    assert mult_c.left is add_ab
+    assert mult_c.right is c
+    assert add_ab.left is a
+    assert add_ab.right is b
+
+
+def test_complex_conditional_graph():
+    """Test building a complex conditional computation graph."""
+    # Build a multi-clause conditional expression
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+
+    cond1 = graph.less(x, graph.constant(0.0))
+    cond2 = graph.greater(x, graph.constant(1.0))
+
+    val1 = graph.multiply(y, graph.constant(-1.0))
+    val2 = graph.exp(y)
+    default = y
+
+    result = graph.multi_clause_where([(cond1, val1), (cond2, val2)], default)
+
+    # Verify structure
+    assert len(result.clauses) == 2
+    assert result.clauses[0][0] is cond1
+    assert result.clauses[0][1] is val1
+    assert result.clauses[1][0] is cond2
+    assert result.clauses[1][1] is val2
+    assert result.default_value is default
+
+
+def test_probability_distribution_graph():
+    """Test building a probability distribution computation graph."""
+    x = graph.placeholder("x")
+    mu = graph.placeholder("mu")
+    sigma = graph.placeholder("sigma")
+
+    # Build normal CDF composed with uniform CDF
+    normal = graph.normal_cdf(x, mu, sigma)
+    result = graph.uniform_cdf(normal, graph.constant(0.0), graph.constant(1.0))
+
+    # Verify structure
+    assert result.x is normal
+    assert result.loc.value == 0.0
+    assert result.scale.value == 1.0
+    assert normal.x is x
+    assert normal.loc is mu
+    assert normal.scale is sigma
+
+
+def test_reduction_graph():
+    """Test building a graph with reduction operations."""
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+
+    # Build mean(sum(x * y, axis=0), axis=1)
+    prod = graph.multiply(x, y)
+    sum_0 = graph.reduce_sum(prod, axis=0)
+    result = graph.reduce_mean(sum_0, axis=1)
+
+    # Verify structure
+    assert result.node is sum_0
+    assert result.axis == 1
+    assert sum_0.node is prod
+    assert sum_0.axis == 0
+    assert prod.left is x
+    assert prod.right is y
+
+
+def test_name_propagation():
+    """Test name handling across operations."""
+    # Test explicit naming
+    a = graph.placeholder("input_a", 1.0)
+    b = graph.constant(2.0, name="const_b")
+    c = graph.add(a, b)
+
+    assert a.name == "input_a"
+    assert b.name == "const_b"
+    assert c.name == ""  # Operations don't get automatic names
+
+
+def test_name_uniqueness():
+    """Test that nodes with same names remain distinct."""
+    a1 = graph.placeholder("x", 1.0)
+    a2 = graph.placeholder("x", 2.0)
+
+    assert a1.name == a2.name == "x"
+    assert a1 is not a2
+    assert hash(a1) != hash(a2)
+
+
+def test_debug_operations_name_preservation():
+    """Test that debug operations preserve names."""
+    a = graph.placeholder("debug_node", 1.0)
+
+    traced = graph.tracepoint(a)
+    assert traced.name == "debug_node"
+    assert traced is a
+
+    breakpointed = graph.breakpoint(traced)
+    assert breakpointed.name == "debug_node"
+    assert breakpointed is a

--- a/yakof/frontend/__init__.py
+++ b/yakof/frontend/__init__.py
@@ -1,0 +1,3 @@
+"""Tensor language frontend."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/yakof/frontend/graph.py
+++ b/yakof/frontend/graph.py
@@ -1,0 +1,351 @@
+"""
+Computation Graph Building
+==========================
+
+This module allows to build an abstract computation graph using TensorFlow-like
+computation primitives and concepts. These primitives and concepts are similar to
+NumPy primitives, but we picked up TensorFlow ones when they disagree. For
+probability distributions, instead, we follow SciPy conventions.
+
+This module provides:
+
+1. Basic node types for constants and placeholders
+2. Arithmetic operations (add, subtract, multiply, divide)
+3. Comparison operations (equal, not_equal, less, less_equal, greater, greater_equal)
+4. Logical operations (and, or, xor, not)
+5. Mathematical operations (exp, power, log)
+6. Shape manipulation operations (expand_dims, squeeze)
+7. Reduction operations (sum, mean)
+
+The nodes form a directed acyclic graph (DAG) that represents computations
+to be performed. Each node implements a specific operation and stores its
+inputs as attributes. The graph can then be evaluated by traversing the nodes
+and performing their operations using NumPy, TensorFlow, etc.
+
+Here's an example of what you can do with this module:
+
+    >>> from yakof.frontend import graph
+    >>> a = graph.placeholder("a", 1.0)
+    >>> b = graph.constant(2.0)
+    >>> c = graph.add(a, b)
+    >>> d = grap.multiply(c, c)
+
+Like TensorFlow, we support placeholders. That is, variables with a given
+name that can be filled in at execution time with concrete values. We also
+support constants, which must be bool, float, or int scalars.
+
+Because our goal is to *capture* the arguments provided to function invocations
+for later evaluation, we are using classes instead of functions. (We could
+alternatively have used closures, but it would have been more clumsy.) To keep
+the invoked entities names as close as possible to TensorFlow, we named the
+classes using snake_case rather than CamelCase. This is a pragmatic and conscious
+choice: violating PEP8 to produce code that reads like TensorFlow or NumPy.
+
+The main type in this module is the `Node`, representing a node in the
+computation graph. Each operation (e.g., `add`) is a subclass of the `Node`
+capturing the arguments it has been provided on construction.
+
+Design Decisions
+----------------
+
+1. Class-based vs Function-based:
+   - Classes capture operation arguments naturally
+   - Enable visitor pattern for transformations
+   - Allow future addition of operation-specific attributes
+
+2. Snake Case Operation Names:
+   - Match NumPy/TensorFlow conventions
+   - Improve readability in mathematical context
+
+3. Node Identity:
+   - Nodes are identified by their instance identity
+   - Enables graph traversal and transformation
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+Axis = int | tuple[int, ...]
+"""Type alias for axis specifications in shape operations."""
+
+Scalar = bool | float | int
+"""Type alias for supported scalar value types."""
+
+
+NODE_FLAG_TRACE = 1 << 0
+"""Inserts a tracepoint at the corresponding graph node."""
+
+NODE_FLAG_BREAK = 1 << 1
+"""Inserts a breakpoint at the corresponding graph node."""
+
+
+class Node:
+    """Base class for all computation graph nodes."""
+
+    def __init__(self, name: str = "") -> None:
+        self.name = name
+        self.flags = 0
+
+    def __hash__(self) -> int:
+        return id(self)  # hashing by identity
+
+
+class constant(Node):
+    """A constant scalar value in the computation graph.
+
+    Args:
+        value: The scalar value to store in this node.
+    """
+
+    def __init__(self, value: Scalar, name: str = "") -> None:
+        super().__init__(name)
+        self.value = value
+
+
+class placeholder(Node):
+    """Named placeholder for a value to be provided during evaluation.
+
+    Args:
+        default_value: Optional default scalar value to use for the
+        placeholder if no type is provided at evaluation time.
+    """
+
+    def __init__(self, name: str, default_value: Scalar | None = None) -> None:
+        super().__init__(name)
+        self.default_value = default_value
+
+
+class BinaryOp(Node):
+    """Base class for binary operations with broadcasting.
+
+    Args:
+        left: First input node
+        right: Second input node
+    """
+
+    def __init__(self, left: Node, right: Node) -> None:
+        super().__init__()
+        self.left = left
+        self.right = right
+
+
+# Arithmetic operations
+
+
+class add(BinaryOp):
+    """Element-wise addition of two tensors."""
+
+
+class subtract(BinaryOp):
+    """Element-wise subtraction of two tensors."""
+
+
+class multiply(BinaryOp):
+    """Element-wise multiplication of two tensors."""
+
+
+class divide(BinaryOp):
+    """Element-wise division of two tensors."""
+
+
+# Comparison operations
+
+
+class equal(BinaryOp):
+    """Element-wise equality comparison of two tensors."""
+
+
+class not_equal(BinaryOp):
+    """Element-wise inequality comparison of two tensors."""
+
+
+class less(BinaryOp):
+    """Element-wise less-than comparison of two tensors."""
+
+
+class less_equal(BinaryOp):
+    """Element-wise less-than-or-equal comparison of two tensors."""
+
+
+class greater(BinaryOp):
+    """Element-wise greater-than comparison of two tensors."""
+
+
+class greater_equal(BinaryOp):
+    """Element-wise greater-than-or-equal comparison of two tensors."""
+
+
+# Logical operations
+
+
+class logical_and(BinaryOp):
+    """Element-wise logical AND of two boolean tensors."""
+
+
+class logical_or(BinaryOp):
+    """Element-wise logical OR of two boolean tensors."""
+
+
+class logical_xor(BinaryOp):
+    """Element-wise logical XOR of two boolean tensors."""
+
+
+class UnaryOp(Node):
+    """Base class for unary operations.
+
+    Args:
+        node: Input node
+    """
+
+    def __init__(self, node: Node) -> None:
+        super().__init__()
+        self.node = node
+
+
+class logical_not(UnaryOp):
+    """Element-wise logical NOT of a boolean tensor."""
+
+
+# Math operations
+
+
+class exp(UnaryOp):
+    """Element-wise exponential of a tensor."""
+
+
+class power(BinaryOp):
+    """Element-wise power operation (first tensor raised to power of second)."""
+
+
+pow = power
+"""Alias for power for compatibility with NumPy naming."""
+
+
+class log(UnaryOp):
+    """Element-wise natural logarithm of a tensor."""
+
+
+class maximum(BinaryOp):
+    """Element-wise maximum of two tensors."""
+
+
+# Conditional operations
+
+
+class where(Node):
+    """Selects elements from tensors based on a condition.
+
+    Args:
+        condition: Boolean tensor
+        then: Values to use where condition is True
+        otherwise: Values to use where condition is False
+    """
+
+    def __init__(self, condition: Node, then: Node, otherwise: Node) -> None:
+        super().__init__()
+        self.condition = condition
+        self.then = then
+        self.otherwise = otherwise
+
+
+class multi_clause_where(Node):
+    """Selects elements from tensors based on multiple conditions.
+
+    Args:
+        clauses: List of (condition, value) pairs
+        default_value: Value to use when no condition is met
+    """
+
+    def __init__(
+        self, clauses: Sequence[tuple[Node, Node]], default_value: Node
+    ) -> None:
+        super().__init__()
+        self.clauses = clauses
+        self.default_value = default_value
+
+
+# Shape-changing operations
+
+
+class AxisOp(Node):
+    """Base class for axis manipulation operations.
+
+    Args:
+        node: Input tensor
+        axis: Axis specification
+    """
+
+    def __init__(self, node: Node, axis: Axis) -> None:
+        super().__init__()
+        self.node = node
+        self.axis = axis
+
+
+class expand_dims(AxisOp):
+    """Adds new axes of size 1 to a tensor's shape."""
+
+
+class squeeze(AxisOp):
+    """Removes axes of size 1 from a tensor's shape."""
+
+
+class reduce_sum(AxisOp):
+    """Computes sum of tensor elements along specified axes."""
+
+
+class reduce_mean(AxisOp):
+    """Computes mean of tensor elements along specified axes."""
+
+
+# Probability distributions
+
+
+class normal_cdf(Node):
+    """Compute CDF of normal distribution."""
+
+    def __init__(self, x: Node, loc: Node, scale: Node) -> None:
+        super().__init__()
+        self.x = x
+        self.loc = loc
+        self.scale = scale
+
+
+class uniform_cdf(Node):
+    """Compute CDF of uniform distribution."""
+
+    def __init__(self, x: Node, loc: Node, scale: Node) -> None:
+        super().__init__()
+        self.x = x
+        self.loc = loc
+        self.scale = scale
+
+
+# Debug operations
+
+
+def tracepoint(node: Node) -> Node:
+    """
+    Marks the node as a tracepoint and returns it. The tracepoint
+    will take effect after the node has been evaluated.
+
+    This function acts like the unit in the category with semantic side
+    effects depending on the debug operation that is requested.
+    """
+    node.flags |= NODE_FLAG_TRACE
+    return node
+
+
+def breakpoint(node: Node) -> Node:
+    """
+    Marks the node as a breakpoint and returns it. The breakpoint
+    will take effect after the node has been evaluated.
+
+    This function acts like the unit in the category with semantic side
+    effects depending on the debug operation that is requested.
+    """
+    node.flags |= NODE_FLAG_TRACE | NODE_FLAG_BREAK
+    return node


### PR DESCRIPTION
The yakof.frontend.graph package is a refactoring of the yakof.backend.graph package focusing on just building a computation graph.

The yakof.frontend.graph name captures more precisely what we are doing: when building a computation graph, we are in the "compiler" frontend. The backend name, instead, seems more proper if reserved for numpy operations.

Compared to yakof.backend.graph, we have distilled features and omitted unnecessary features, such as the ability to use operations directly.

While there, also add unit tests for the yakof.frontend.graph package.