### PR TITLE
feat(yakof.numpybackend): add reference evaluator

### DIFF
--- a/yakof/frontend/graph.py
+++ b/yakof/frontend/graph.py
@@ -84,14 +84,32 @@ NODE_FLAG_BREAK = 1 << 1
 
 
 class Node:
-    """Base class for all computation graph nodes."""
+    """
+    Base class for all computation graph nodes.
+
+    Design Notes
+    ------------
+
+    1. Identity Semantics:
+        - Nodes use identity-based hashing and equality
+        - This allows graph traversal algorithms to work correctly
+        - Enables use of nodes as dictionary keys
+
+    2. Debug Support:
+        - Nodes carry flags for debugging (trace/break)
+        - Names for better error reporting
+        - Extensible flag system for future debug features
+    """
 
     def __init__(self, name: str = "") -> None:
         self.name = name
         self.flags = 0
 
     def __hash__(self) -> int:
-        return id(self)  # hashing by identity
+        # Note: introducing hashing by identity in the class inheritance
+        # chain to ensure that overriding the equality operator to be lazy
+        # in derived classes do not break assigning to dicts.
+        return id(self)
 
 
 class constant(Node):

--- a/yakof/frontend/pretty.py
+++ b/yakof/frontend/pretty.py
@@ -1,0 +1,199 @@
+"""
+Pretty Printing for Computation Graphs
+======================================
+
+This module provides facilities for converting computation graphs into
+readable string representations. It handles:
+
+1. Operator precedence
+2. Parentheses insertion
+3. Special formatting for function-like operations
+4. Named expressions
+
+The main entry point is the format() function:
+
+    >>> from yakof.frontend import graph, pretty
+    >>> x = graph.placeholder("x")
+    >>> y = graph.add(graph.multiply(x, 2), 1)
+    >>> print(pretty.format(y))
+    x * 2 + 1
+
+Precedence Rules
+---------------
+
+The formatter follows standard mathematical precedence:
+
+1. Function application (exp, log)
+2. Unary operations (~)
+3. Power (**)
+4. Multiply/Divide (*, /)
+5. Add/Subtract (+, -)
+6. Comparisons (<, <=, >, >=, ==, !=)
+7. Logical AND (&)
+8. Logical OR/XOR (|, ^)
+
+Parentheses are automatically added when needed to preserve
+the correct evaluation order:
+
+    >>> x + y * z      # "x + y * z"
+    >>> (x + y) * z    # "(x + y) * z"
+    >>> ~x & y | z     # "(~x & y) | z"
+
+Design Decisions
+---------------
+1. Precedence-based Formatting:
+   - Uses numeric precedence levels to determine parenthesization
+   - Follows standard mathematical conventions
+   - Allows easy addition of new operators
+
+2. Recursive Implementation:
+   - Handles nested expressions naturally
+   - Passes precedence information down the tree
+   - Enables context-aware formatting decisions
+
+3. Special Cases:
+   - Function-like operations use function call syntax
+   - Named nodes show assignment syntax
+   - Placeholders use angle bracket notation for visibility
+
+Implementation Notes
+------------------
+The formatter uses a visitor-like pattern without explicitly implementing
+the visitor pattern, which keeps the code simpler while maintaining
+extensibility.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yakof.frontend import graph
+
+
+def format(node: graph.Node) -> str:
+    """Format a computation graph node as a string.
+
+    Args:
+        node: The node to format
+
+    Returns:
+        A string representation with appropriate parentheses
+        and operator precedence.
+
+    Examples:
+        >>> x = graph.placeholder("x")
+        >>> y = graph.add(graph.multiply(x, 2), 1)
+        >>> print(pretty.format(y))
+        x * 2 + 1
+    """
+    expr = _format(node, 0)  # Start with lowest precedence
+    if node.name:
+        expr = f"{node.name} = {expr}"
+    return expr
+
+
+def _format(node: graph.Node, parent_precedence: int) -> str:
+    """Internal recursive formatter.
+
+    Args:
+        node: The node to format
+        parent_precedence: The precedence of the parent operation
+
+    Returns:
+        Formatted string with appropriate parentheses based on
+        operator precedence.
+    """
+    # Precedence rules (higher binds tighter)
+    PRECEDENCE = {
+        # Unary operations
+        graph.logical_not: 50,  # ~x
+        graph.exp: 50,  # exp(x)
+        graph.log: 50,  # log(x)
+        # Binary operations
+        graph.power: 40,  # x ** y
+        graph.multiply: 30,  # x * y
+        graph.divide: 30,  # x / y
+        graph.add: 20,  # x + y
+        graph.subtract: 20,  # x - y
+        # Comparisons
+        graph.less: 10,  # x < y
+        graph.less_equal: 10,  # x <= y
+        graph.greater: 10,  # x > y
+        graph.greater_equal: 10,  # x >= y
+        graph.equal: 10,  # x == y
+        graph.not_equal: 10,  # x != y
+        # Logical operations
+        graph.logical_and: 5,  # x & y
+        graph.logical_or: 4,  # x | y
+        graph.logical_xor: 4,  # x ^ y
+    }
+
+    def needs_parens(node: graph.Node) -> bool:
+        """Determine if expression needs parentheses."""
+        return PRECEDENCE.get(type(node), 0) < parent_precedence
+
+    def wrap(expr: str) -> str:
+        """Wrap expression in parentheses if needed."""
+        return f"({expr})" if needs_parens(node) else expr
+
+    # Base cases
+    if isinstance(node, graph.constant):
+        return str(node.value)
+    if isinstance(node, graph.placeholder):
+        return f"<{node.name}>"
+
+    # Binary operations
+    if isinstance(node, graph.BinaryOp):
+        op_precedence = PRECEDENCE.get(type(node), 0)
+        left = _format(node.left, op_precedence)
+        right = _format(node.right, op_precedence)
+
+        # Arithmetic operators
+        if isinstance(node, graph.add):
+            return wrap(f"{left} + {right}")
+        if isinstance(node, graph.subtract):
+            return wrap(f"{left} - {right}")
+        if isinstance(node, graph.multiply):
+            return wrap(f"{left} * {right}")
+        if isinstance(node, graph.divide):
+            return wrap(f"{left} / {right}")
+        if isinstance(node, graph.power):
+            return wrap(f"{left} ** {right}")
+        if isinstance(node, graph.logical_and):
+            return wrap(f"{left} & {right}")
+        if isinstance(node, graph.logical_or):
+            return wrap(f"{left} | {right}")
+        if isinstance(node, graph.logical_xor):
+            return wrap(f"{left} ^ {right}")
+
+        # Comparison operators
+        if isinstance(node, graph.less):
+            return wrap(f"{left} < {right}")
+        if isinstance(node, graph.less_equal):
+            return wrap(f"{left} <= {right}")
+        if isinstance(node, graph.greater):
+            return wrap(f"{left} > {right}")
+        if isinstance(node, graph.greater_equal):
+            return wrap(f"{left} >= {right}")
+        if isinstance(node, graph.equal):
+            return wrap(f"{left} == {right}")
+        if isinstance(node, graph.not_equal):
+            return wrap(f"{left} != {right}")
+
+    # Unary operations
+    if isinstance(node, graph.UnaryOp):
+        op_precedence = PRECEDENCE.get(type(node), 0)
+        inner = _format(node.node, op_precedence)
+
+        if isinstance(node, graph.logical_not):
+            return wrap(f"~{inner}")
+        if isinstance(node, graph.exp):
+            return f"exp({inner})"
+        if isinstance(node, graph.log):
+            return f"log({inner})"
+
+    # Function-like operations
+    if isinstance(node, graph.normal_cdf):
+        return f"normal_cdf({_format(node.x, 0)}, loc={_format(node.loc, 0)}, scale={_format(node.scale, 0)})"
+    if isinstance(node, graph.uniform_cdf):
+        return f"uniform_cdf({_format(node.x, 0)}, loc={_format(node.loc, 0)}, scale={_format(node.scale, 0)})"
+
+    return f"<unknown:{type(node).__name__}>"

--- a/yakof/numpybackend/__init__.py
+++ b/yakof/numpybackend/__init__.py
@@ -1,0 +1,3 @@
+"""NumPy backend."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/yakof/numpybackend/evaluator.py
+++ b/yakof/numpybackend/evaluator.py
@@ -1,0 +1,205 @@
+"""
+NumPy evaluator
+===============
+
+Evaluates a `graph.Node` by calling the corresponding NumPy
+functions and producing a `numpy.ndarray` as output.
+
+We consider this implementation the reference implementation and we
+strive to keep it simple and easy to understand. We may write more
+complex implementations if benchmarks show there are bottlenecks, but
+we generally strive to keep a simple implementation around.
+
+Design Decisions
+---------------
+1. Lazy Evaluation:
+   - Uses dictionary-based caching
+   - Prevents redundant computations
+   - Preserves DAG semantics
+
+2. Debug Support:
+   - Integrated tracepoints and breakpoints
+   - Rich debug output including shape information
+   - Non-intrusive to normal evaluation path
+
+3. Error Handling:
+   - Descriptive error messages
+   - Type checking for operations
+   - Validation of placeholder bindings
+
+Implementation Notes
+------------------
+The evaluator uses operation-type dispatch tables to keep the code
+maintainable and extensible. New operations can be added by extending
+the dispatch tables without modifying the core evaluation logic.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..frontend import graph, pretty
+
+
+Bindings = dict[str, np.ndarray]
+"""Type alias for a dictionary of variable bindings."""
+
+
+Cache = dict[graph.Node, np.ndarray]
+"""Type alias for a dictionary tracking already-computed node values."""
+
+
+def _print_tracepoint(node: graph.Node, value: np.ndarray) -> None:
+    print("=== begin tracepoint ===")
+    print(f"name: {node.name}")
+    print(f"formula: {pretty.format(node)}")
+    print(f"shape: {value.shape}")
+    print(f"value:\n{value}")
+    print("=== end tracepoint ===")
+    print("")
+
+
+def evaluate(
+    node: graph.Node,
+    bindings: Bindings,
+    cache: Cache | None = None,
+) -> np.ndarray:
+    """Evaluates a computation graph node to a NumPy array.
+
+    This function performs a depth-first traversal of the computation graph,
+    evaluating each node's inputs before computing its result.
+
+    The evaluation strategy is:
+
+    1. Check cache for previously computed results
+    2. For leaf nodes (constants/placeholders):
+       - Convert to numpy arrays
+       - Validate types and values
+    3. For operation nodes:
+       - Recursively evaluate inputs
+       - Apply corresponding numpy operation
+       - Handle broadcasting and shape compatibility
+    4. Apply any debug operations (trace/break)
+    5. Cache and return result
+
+    Args:
+        node: Root node of the computation graph to evaluate
+        bindings: Dictionary mapping placeholder names to concrete values
+        cache: Optional cache of previously computed node values
+
+    Returns:
+        Computed numpy array result
+
+    Raises:
+        TypeError: if we don't handle a specific node type
+        ValueError: when there's no placeholder value
+    """
+
+    # Use cache if available
+    if cache and node in cache:
+        return cache[node]
+
+    # Code to run before returning
+    def __before_return(value: np.ndarray) -> np.ndarray:
+        if node.flags & graph.NODE_FLAG_TRACE != 0:
+            _print_tracepoint(node, value)
+        if node.flags & graph.NODE_FLAG_BREAK != 0:
+            input("Press any key to continue...")
+        if cache:
+            cache[node] = value
+        return value
+
+    # Constant operation
+    if isinstance(node, graph.constant):
+        return __before_return(np.asarray(node.value))
+
+    # Placeholder operation
+    if isinstance(node, graph.placeholder):
+        if node.name not in bindings:
+            if node.default_value is not None:
+                return __before_return(np.asarray(node.default_value))
+            raise ValueError(
+                f"evaluator: no value provided for placeholder '{node.name}'"
+            )
+        return __before_return(bindings[node.name])
+
+    # Binary operations
+    if isinstance(node, graph.BinaryOp):
+        left = evaluate(node.left, bindings, cache)
+        right = evaluate(node.right, bindings, cache)
+
+        ops = {
+            graph.add: np.add,
+            graph.subtract: np.subtract,
+            graph.multiply: np.multiply,
+            graph.divide: np.divide,
+            graph.equal: np.equal,
+            graph.not_equal: np.not_equal,
+            graph.less: np.less,
+            graph.less_equal: np.less_equal,
+            graph.greater: np.greater,
+            graph.greater_equal: np.greater_equal,
+            graph.logical_and: np.logical_and,
+            graph.logical_or: np.logical_or,
+            graph.logical_xor: np.logical_xor,
+            graph.power: np.power,
+            graph.maximum: np.maximum,
+        }
+
+        try:
+            return __before_return(ops[type(node)](left, right))
+        except KeyError:
+            raise TypeError(f"evaluator: unknown binary operation: {type(node)}")
+
+    # Unary operations
+    if isinstance(node, graph.UnaryOp):
+        operand = evaluate(node.node, bindings, cache)
+
+        ops = {
+            graph.logical_not: np.logical_not,
+            graph.exp: np.exp,
+            graph.log: np.log,
+        }
+
+        try:
+            return __before_return(ops[type(node)](operand))
+        except KeyError:
+            raise TypeError(f"evaluator: unknown unary operation: {type(node)}")
+
+    # Conditional operations
+    if isinstance(node, graph.where):
+        return __before_return(
+            np.where(
+                evaluate(node.condition, bindings, cache),
+                evaluate(node.then, bindings, cache),
+                evaluate(node.otherwise, bindings, cache),
+            )
+        )
+
+    if isinstance(node, graph.multi_clause_where):
+        conditions = []
+        values = []
+        for cond, value in node.clauses[:-1]:
+            conditions.append(evaluate(cond, bindings, cache))
+            values.append(evaluate(value, bindings, cache))
+        default = evaluate(node.default_value, bindings, cache)
+        return __before_return(np.select(conditions, values, default=default))
+
+    # Axis operations
+    if isinstance(node, graph.AxisOp):
+        operand = evaluate(node.node, bindings, cache)
+
+        ops = {
+            graph.expand_dims: lambda x: np.expand_dims(x, node.axis),
+            graph.reduce_sum: lambda x: np.sum(x, axis=node.axis),
+            graph.reduce_mean: lambda x: np.mean(x, axis=node.axis),
+        }
+
+        try:
+            return __before_return(ops[type(node)](operand))
+        except KeyError:
+            raise TypeError(f"evaluator: unknown axis operation: {type(node)}")
+
+    raise TypeError(f"evaluator: unknown node type: {type(node)}")


### PR DESCRIPTION
This commit adds a tree walking reference evaluator. We strive to keep it simple and easy to understand. We'll use more complex strategies, if benchmarks and real use cases show it's a memory or CPU bottleneck.

While there, generally strive to improve docs.

Also, note that, to implement the numpybackend, we also need a graph pretty printing functionality in tree.