### PR TITLE
feat(numpybackend.evaluator): add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/.coverage
+/coverage.xml
 __pycache__/
 /.venv

--- a/tests/numpybackend/__init__.py
+++ b/tests/numpybackend/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the yakof.numpybackend package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/numpybackend/test_evaluator.py
+++ b/tests/numpybackend/test_evaluator.py
@@ -83,6 +83,18 @@ def test_comparison_operations():
     node = graph.equal(graph.placeholder("x"), graph.placeholder("y"))
     assert np.array_equal(evaluator.evaluate(node, state), x == y)
 
+    # Not equal
+    node = graph.not_equal(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, state), x != y)
+
+    # Less than or equal
+    node = graph.less_equal(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, state), x <= y)
+
+    # Greater than or equal
+    node = graph.greater_equal(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, state), x >= y)
+
 
 def test_logical_operations():
     """Test evaluation of logical operations."""
@@ -200,8 +212,8 @@ def test_where_operation():
         assert np.array_equal(result, expected)
 
 
-def test_debug_operations(capsys):
-    """Test debug operations (tracepoint/breakpoint)."""
+def test_tracepoint_operation(capsys):
+    """Test tracepoint operation."""
     x = graph.placeholder("x")
     traced = graph.tracepoint(x)
 
@@ -383,8 +395,6 @@ def test_breakpoint_operation(monkeypatch):
 
 def test_state_management():
     """Test state management edge cases."""
-
-    # Test cache invalidation ordering
     state = evaluator.StateWithCache({})
     x = graph.placeholder("x")
     y = graph.add(x, x)

--- a/tests/numpybackend/test_evaluator.py
+++ b/tests/numpybackend/test_evaluator.py
@@ -1,0 +1,208 @@
+"""Tests for the yakof.numpybackend.evaluator module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from yakof.frontend import graph
+from yakof.numpybackend import evaluator
+
+
+def test_constant_evaluation():
+    """Test evaluation of constant nodes."""
+    # Scalar constants
+    assert np.array_equal(evaluator.evaluate(graph.constant(1.0), {}), np.array(1.0))
+    assert np.array_equal(evaluator.evaluate(graph.constant(True), {}), np.array(True))
+    assert np.array_equal(evaluator.evaluate(graph.constant(42), {}), np.array(42))
+
+
+def test_placeholder_evaluation():
+    """Test evaluation of placeholder nodes."""
+    x = graph.placeholder("x")
+    y = graph.placeholder("y", default_value=3.14)
+
+    # Test with binding
+    assert np.array_equal(evaluator.evaluate(x, {"x": np.array(2.0)}), np.array(2.0))
+
+    # Test default value
+    assert np.array_equal(evaluator.evaluate(y, {}), np.array(3.14))
+
+    # Test missing binding
+    with pytest.raises(ValueError, match="no value provided for placeholder 'x'"):
+        evaluator.evaluate(x, {})
+
+
+def test_arithmetic_operations():
+    """Test evaluation of arithmetic operations."""
+    x = np.array(2.0)
+    y = np.array(3.0)
+    bindings = {"x": x, "y": y}
+
+    # Addition
+    node = graph.add(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), x + y)
+
+    # Subtraction
+    node = graph.subtract(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), x - y)
+
+    # Multiplication
+    node = graph.multiply(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), x * y)
+
+    # Division
+    node = graph.divide(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), x / y)
+
+
+def test_comparison_operations():
+    """Test evaluation of comparison operations."""
+    x = np.array(2.0)
+    y = np.array(3.0)
+    bindings = {"x": x, "y": y}
+
+    # Less than
+    node = graph.less(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), x < y)
+
+    # Greater than
+    node = graph.greater(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), x > y)
+
+    # Equal
+    node = graph.equal(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), x == y)
+
+
+def test_logical_operations():
+    """Test evaluation of logical operations."""
+    x = np.array(True)
+    y = np.array(False)
+    bindings = {"x": x, "y": y}
+
+    # AND
+    node = graph.logical_and(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), np.logical_and(x, y))
+
+    # OR
+    node = graph.logical_or(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), np.logical_or(x, y))
+
+    # NOT
+    node = graph.logical_not(graph.placeholder("x"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), np.logical_not(x))
+
+
+def test_math_operations():
+    """Test evaluation of mathematical operations."""
+    x = np.array(2.0)
+    bindings = {"x": x}
+
+    # Exponential
+    node = graph.exp(graph.placeholder("x"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), np.exp(x))
+
+    # Logarithm
+    node = graph.log(graph.placeholder("x"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), np.log(x))
+
+    # Power
+    node = graph.power(graph.placeholder("x"), graph.constant(2.0))
+    assert np.array_equal(evaluator.evaluate(node, bindings), np.power(x, 2.0))
+
+
+def test_broadcasting():
+    """Test broadcasting behavior in operations."""
+    x = np.array([[1.0, 2.0], [3.0, 4.0]])
+    y = np.array([10.0, 20.0])
+    bindings = {"x": x, "y": y}
+
+    # Broadcasting in addition
+    node = graph.add(graph.placeholder("x"), graph.placeholder("y"))
+    assert np.array_equal(evaluator.evaluate(node, bindings), x + y)
+
+
+def test_reduction_operations():
+    """Test evaluation of reduction operations."""
+    x = np.array([[1.0, 2.0], [3.0, 4.0]])
+    bindings = {"x": x}
+
+    # Sum reduction
+    node = graph.reduce_sum(graph.placeholder("x"), axis=0)
+    assert np.array_equal(evaluator.evaluate(node, bindings), np.sum(x, axis=0))
+
+    # Mean reduction
+    node = graph.reduce_mean(graph.placeholder("x"), axis=1)
+    assert np.array_equal(evaluator.evaluate(node, bindings), np.mean(x, axis=1))
+
+
+def test_conditional_operations():
+    """Test evaluation of conditional operations."""
+    # Test simple where operation first
+    cond = np.array([True, False, True])
+    x = np.array([1.0, 2.0, 3.0])
+    y = np.array([4.0, 5.0, 6.0])
+    bindings = {"cond": cond, "x": x, "y": y}
+
+    # Simple where
+    node = graph.where(
+        graph.placeholder("cond"), graph.placeholder("x"), graph.placeholder("y")
+    )
+    result = evaluator.evaluate(node, bindings)
+    expected = np.where(cond, x, y)
+    assert np.array_equal(result, expected)
+
+    # Print intermediate values for debugging
+    print(f"cond: {cond}")
+    print(f"x: {x}")
+    print(f"y: {y}")
+    print(f"result: {result}")
+    print(f"expected: {expected}")
+
+
+def test_caching():
+    """Test that evaluation caching works correctly."""
+    # Create a simple expression that we can verify caching with
+    x = graph.placeholder("x")
+    const = graph.constant(2.0)
+    expr = graph.multiply(x, const)  # x * 2
+
+    # First evaluation
+    cache = {}
+    x_val = np.array(3.0)
+    result1 = evaluator.evaluate(expr, {"x": x_val}, cache)
+
+    # Second evaluation - should use cache
+    result2 = evaluator.evaluate(expr, {"x": x_val}, cache)
+
+    # Results should be identical
+    assert np.array_equal(result1, result2)
+    assert np.array_equal(result1, x_val * 2)
+
+    # Print cache contents for debugging
+    print("Cache contents:")
+    for k, v in cache.items():
+        print(f"  {k}: {v}")
+
+
+def test_debug_operations(capsys):
+    """Test debug operations (tracepoint/breakpoint)."""
+    x = graph.placeholder("x")
+    traced = graph.tracepoint(x)
+
+    evaluator.evaluate(traced, {"x": np.array(1.0)})
+    captured = capsys.readouterr()
+    assert "=== begin tracepoint ===" in captured.out
+    assert "value" in captured.out
+
+
+def test_error_handling():
+    """Test various error conditions."""
+
+    # Unknown operation type
+    class unknown_op(graph.Node):
+        pass
+
+    with pytest.raises(TypeError, match="unknown node type"):
+        evaluator.evaluate(unknown_op(), {})

--- a/tests/numpybackend/test_evaluator.py
+++ b/tests/numpybackend/test_evaluator.py
@@ -14,7 +14,9 @@ def test_constant_evaluation():
     # Scalar constants
     state = evaluator.StateWithoutCache({})
     assert np.array_equal(evaluator.evaluate(graph.constant(1.0), state), np.array(1.0))
-    assert np.array_equal(evaluator.evaluate(graph.constant(True), state), np.array(True))
+    assert np.array_equal(
+        evaluator.evaluate(graph.constant(True), state), np.array(True)
+    )
     assert np.array_equal(evaluator.evaluate(graph.constant(42), state), np.array(42))
 
 
@@ -24,8 +26,12 @@ def test_placeholder_evaluation():
     y = graph.placeholder("y", default_value=3.14)
 
     # Test with binding
-    state = evaluator.StateWithoutCache({"x": np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])})
-    assert np.array_equal(evaluator.evaluate(x, state), np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+    state = evaluator.StateWithoutCache(
+        {"x": np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])}
+    )
+    assert np.array_equal(
+        evaluator.evaluate(x, state), np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    )
 
     # Test default value
     state = evaluator.StateWithoutCache({})
@@ -150,7 +156,9 @@ def test_where_operation():
     test_cases = [
         # 3x3 matrix selection
         {
-            "cond": np.array([[True, False, True], [False, True, False], [True, False, True]]),
+            "cond": np.array(
+                [[True, False, True], [False, True, False], [True, False, True]]
+            ),
             "x": np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
             "y": np.array([[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]]),
             "desc": "3x3 matrices",

--- a/yakof/numpybackend/evaluator.py
+++ b/yakof/numpybackend/evaluator.py
@@ -50,7 +50,7 @@ The reference implementation provides two state classes:
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
-from typing import Callable, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 import numpy as np
 

--- a/yakof/numpybackend/evaluator.py
+++ b/yakof/numpybackend/evaluator.py
@@ -1,6 +1,6 @@
 """
-NumPy evaluator
-===============
+NumPy Reference Evaluator
+=========================
 
 Evaluates a `graph.Node` by calling the corresponding NumPy
 functions and producing a `numpy.ndarray` as output.
@@ -8,47 +8,146 @@ functions and producing a `numpy.ndarray` as output.
 We consider this implementation the reference implementation and we
 strive to keep it simple and easy to understand. We may write more
 complex implementations if benchmarks show there are bottlenecks, but
-we generally strive to keep a simple implementation around.
+we generally wish to keep a simple implementation around.
 
 Design Decisions
 ---------------
-1. Lazy Evaluation:
-   - Uses dictionary-based caching
-   - Prevents redundant computations
-   - Preserves DAG semantics
+1. State Management:
+   - Uses Protocol to define state interface
+   - Separates bindings from caching concerns
+   - Provides both caching and non-caching implementations
+   - Simple cache invalidation on input changes
 
-2. Debug Support:
+2. Lazy Evaluation:
+   - Optional caching of intermediate results
+   - Prevents redundant computations within a single evaluation
+   - Cache invalidation on placeholder value changes
+   - Clear semantics for cache behavior
+
+3. Debug Support:
    - Integrated tracepoints and breakpoints
    - Rich debug output including shape information
    - Non-intrusive to normal evaluation path
 
-3. Error Handling:
+4. Error Handling:
+    - Validation of placeholder bindings
    - Descriptive error messages
    - Type checking for operations
-   - Validation of placeholder bindings
 
 Implementation Notes
 ------------------
 The evaluator uses operation-type dispatch tables to keep the code
 maintainable and extensible. New operations can be added by extending
 the dispatch tables without modifying the core evaluation logic.
+
+The State protocol allows for different state management strategies while
+maintaining a clear contract for how state (including caching) should behave.
+The reference implementation provides two state classes:
+- StateWithoutCache: Simple bindings management without caching
+- StateWithCache: Adds caching with full invalidation on input changes
 """
 
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+from typing import Callable, Protocol, runtime_checkable
 
 import numpy as np
 
 from ..frontend import graph, pretty
 
 
+@runtime_checkable
+class State(Protocol):
+    """Protocol representing the evaluator state.
+
+    This protocol defines the interface for managing computation state,
+    including placeholder bindings and optional caching of intermediate
+    results.
+
+    Methods:
+        get_node_value: Returns cached value for a node if available
+        set_node_value: Caches a computed node value
+        set_placeholder_value: Updates a placeholder's value
+        get_placeholder_value: Retrieves a placeholder's current value
+
+    Note:
+        Setting a placeholder value after construction invalidates at least part
+        of the already-computed nodes cache and possibly the whole cache.
+
+    Example:
+        >>> state = StateWithCache({"x": np.array(1.0)})
+        >>> state.set_placeholder_value("y", np.array(2.0))
+        >>> state.get_placeholder_value("x")
+        array(1.)
+    """
+
+    def set_node_value(self, key: graph.Node, value: np.ndarray) -> None: ...
+
+    def get_node_value(self, key: graph.Node) -> np.ndarray | None: ...
+
+    def set_placeholder_value(self, key: str, value: np.ndarray) -> None: ...
+
+    def get_placeholder_value(self, key: str) -> np.ndarray | None: ...
+
+
 Bindings = dict[str, np.ndarray]
 """Type alias for a dictionary of variable bindings."""
 
 
-Cache = dict[graph.Node, np.ndarray]
-"""Type alias for a dictionary tracking already-computed node values."""
+class StateWithoutCache:
+    """Implementation of State protocol without result caching.
+
+    This implementation only manages placeholder bindings without
+    caching intermediate computation results. Useful when memory
+    is constrained or when each node needs to be re-evaluated.
+    """
+
+    def __init__(self, bindings: Bindings) -> None:
+        self._bindings = bindings
+
+    def set_node_value(self, key: graph.Node, value: np.ndarray) -> None:
+        pass
+
+    def get_node_value(self, key: graph.Node) -> np.ndarray | None:
+        return None
+
+    def set_placeholder_value(self, key: str, value: np.ndarray) -> None:
+        self._bindings[key] = value
+
+    def get_placeholder_value(self, key: str) -> np.ndarray | None:
+        if key not in self._bindings:
+            return None
+        return self._bindings[key]
+
+
+class StateWithCache(StateWithoutCache):
+    """Implementation of State protocol with result caching.
+
+    This implementation caches intermediate computation results
+    for reuse. The entire cache is invalidated when any placeholder
+    value changes, ensuring computation correctness at the cost of
+    potentially redundant recomputations.
+    """
+
+    def __init__(self, bindings: Bindings) -> None:
+        super().__init__(bindings)
+        self._cache: dict[graph.Node, np.ndarray] = {}
+
+    def set_node_value(self, key: graph.Node, value: np.ndarray) -> None:
+        self._cache[key] = value
+
+    def get_node_value(self, key: graph.Node) -> np.ndarray | None:
+        if key not in self._cache:
+            return None
+        return self._cache[key]
+
+    def set_placeholder_value(self, key: str, value: np.ndarray) -> None:
+        super().set_placeholder_value(key, value)
+        self._cache.clear()
+
+    def get_placeholder_value(self, key: str) -> np.ndarray | None:
+        return super().get_placeholder_value(key)
 
 
 def _print_tracepoint(node: graph.Node, value: np.ndarray) -> None:
@@ -61,11 +160,60 @@ def _print_tracepoint(node: graph.Node, value: np.ndarray) -> None:
     print("")
 
 
-def evaluate(
-    node: graph.Node,
-    bindings: Bindings,
-    cache: Cache | None = None,
-) -> np.ndarray:
+# This dispatch table maps a binary op in the graph domain
+# to the corresponding numpy operation. Add to this table to
+# add support for more binary operations.
+binary_ops_dispatch_table = {
+    graph.add: np.add,
+    graph.subtract: np.subtract,
+    graph.multiply: np.multiply,
+    graph.divide: np.divide,
+    graph.equal: np.equal,
+    graph.not_equal: np.not_equal,
+    graph.less: np.less,
+    graph.less_equal: np.less_equal,
+    graph.greater: np.greater,
+    graph.greater_equal: np.greater_equal,
+    graph.logical_and: np.logical_and,
+    graph.logical_or: np.logical_or,
+    graph.logical_xor: np.logical_xor,
+    graph.power: np.power,
+    graph.maximum: np.maximum,
+}
+
+
+# Like binary_ops_dispatch_table but for unary operations
+unary_ops_dispatch_table = {
+    graph.logical_not: np.logical_not,
+    graph.exp: np.exp,
+    graph.log: np.log,
+}
+
+
+def __expand_dims(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
+    """Internal expand_dims implementation used by axis_ops_dispatch_table"""
+    return np.expand_dims(x, axis)
+
+
+def __reduce_sum(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
+    """Internal reduce_sum implementation used by axis_ops_dispatch_table"""
+    return np.sum(x, axis=axis)
+
+
+def __reduce_mean(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
+    """Internal reduce_mean implementation used by axis_ops_dispatch_table"""
+    return np.mean(x, axis=axis)
+
+
+# Like binary_ops_dispatch_table but for axis operations
+axis_ops_dispatch_table = {
+    graph.expand_dims: __expand_dims,
+    graph.reduce_sum: __reduce_sum,
+    graph.reduce_mean: __reduce_mean,
+}
+
+
+def evaluate(node: graph.Node, state: State) -> np.ndarray:
     """Evaluates a computation graph node to a NumPy array.
 
     This function performs a depth-first traversal of the computation graph,
@@ -73,7 +221,7 @@ def evaluate(
 
     The evaluation strategy is:
 
-    1. Check cache for previously computed results
+    1. Check the state's cache for previously computed results
     2. For leaf nodes (constants/placeholders):
        - Convert to numpy arrays
        - Validate types and values
@@ -82,12 +230,11 @@ def evaluate(
        - Apply corresponding numpy operation
        - Handle broadcasting and shape compatibility
     4. Apply any debug operations (trace/break)
-    5. Cache and return result
+    5. Cache, if enabled, and return result
 
     Args:
         node: Root node of the computation graph to evaluate
-        bindings: Dictionary mapping placeholder names to concrete values
-        cache: Optional cache of previously computed node values
+        state: Execution state including placeholder values and cache
 
     Returns:
         Computed numpy array result
@@ -98,8 +245,9 @@ def evaluate(
     """
 
     # Use cache if available
-    if cache and node in cache:
-        return cache[node]
+    cached_result = state.get_node_value(node)
+    if cached_result is not None:
+        return cached_result
 
     # Code to run before returning
     def __before_return(value: np.ndarray) -> np.ndarray:
@@ -107,8 +255,7 @@ def evaluate(
             _print_tracepoint(node, value)
         if node.flags & graph.NODE_FLAG_BREAK != 0:
             input("Press any key to continue...")
-        if cache:
-            cache[node] = value
+        state.set_node_value(node, value)
         return value
 
     # Constant operation
@@ -117,54 +264,29 @@ def evaluate(
 
     # Placeholder operation
     if isinstance(node, graph.placeholder):
-        if node.name not in bindings:
+        value = state.get_placeholder_value(node.name)
+        if value is None:
             if node.default_value is not None:
                 return __before_return(np.asarray(node.default_value))
             raise ValueError(
                 f"evaluator: no value provided for placeholder '{node.name}'"
             )
-        return __before_return(bindings[node.name])
+        return __before_return(value)
 
     # Binary operations
     if isinstance(node, graph.BinaryOp):
-        left = evaluate(node.left, bindings, cache)
-        right = evaluate(node.right, bindings, cache)
-
-        ops = {
-            graph.add: np.add,
-            graph.subtract: np.subtract,
-            graph.multiply: np.multiply,
-            graph.divide: np.divide,
-            graph.equal: np.equal,
-            graph.not_equal: np.not_equal,
-            graph.less: np.less,
-            graph.less_equal: np.less_equal,
-            graph.greater: np.greater,
-            graph.greater_equal: np.greater_equal,
-            graph.logical_and: np.logical_and,
-            graph.logical_or: np.logical_or,
-            graph.logical_xor: np.logical_xor,
-            graph.power: np.power,
-            graph.maximum: np.maximum,
-        }
-
+        left = evaluate(node.left, state)
+        right = evaluate(node.right, state)
         try:
-            return __before_return(ops[type(node)](left, right))
+            return __before_return(binary_ops_dispatch_table[type(node)](left, right))
         except KeyError:
             raise TypeError(f"evaluator: unknown binary operation: {type(node)}")
 
     # Unary operations
     if isinstance(node, graph.UnaryOp):
-        operand = evaluate(node.node, bindings, cache)
-
-        ops = {
-            graph.logical_not: np.logical_not,
-            graph.exp: np.exp,
-            graph.log: np.log,
-        }
-
+        operand = evaluate(node.node, state)
         try:
-            return __before_return(ops[type(node)](operand))
+            return __before_return(unary_ops_dispatch_table[type(node)](operand))
         except KeyError:
             raise TypeError(f"evaluator: unknown unary operation: {type(node)}")
 
@@ -172,9 +294,9 @@ def evaluate(
     if isinstance(node, graph.where):
         return __before_return(
             np.where(
-                evaluate(node.condition, bindings, cache),
-                evaluate(node.then, bindings, cache),
-                evaluate(node.otherwise, bindings, cache),
+                evaluate(node.condition, state),
+                evaluate(node.then, state),
+                evaluate(node.otherwise, state),
             )
         )
 
@@ -182,23 +304,18 @@ def evaluate(
         conditions = []
         values = []
         for cond, value in node.clauses:
-            conditions.append(evaluate(cond, bindings, cache))
-            values.append(evaluate(value, bindings, cache))
-        default = evaluate(node.default_value, bindings, cache)
+            conditions.append(evaluate(cond, state))
+            values.append(evaluate(value, state))
+        default = evaluate(node.default_value, state)
         return __before_return(np.select(conditions, values, default=default))
 
     # Axis operations
     if isinstance(node, graph.AxisOp):
-        operand = evaluate(node.node, bindings, cache)
-
-        ops = {
-            graph.expand_dims: lambda x: np.expand_dims(x, node.axis),
-            graph.reduce_sum: lambda x: np.sum(x, axis=node.axis),
-            graph.reduce_mean: lambda x: np.mean(x, axis=node.axis),
-        }
-
+        operand = evaluate(node.node, state)
         try:
-            return __before_return(ops[type(node)](operand))
+            return __before_return(
+                axis_ops_dispatch_table[type(node)](operand, node.axis)
+            )
         except KeyError:
             raise TypeError(f"evaluator: unknown axis operation: {type(node)}")
 

--- a/yakof/numpybackend/evaluator.py
+++ b/yakof/numpybackend/evaluator.py
@@ -181,7 +181,7 @@ def evaluate(
     if isinstance(node, graph.multi_clause_where):
         conditions = []
         values = []
-        for cond, value in node.clauses:  # No slice - process all clauses
+        for cond, value in node.clauses:
             conditions.append(evaluate(cond, bindings, cache))
             values.append(evaluate(value, bindings, cache))
         default = evaluate(node.default_value, bindings, cache)

--- a/yakof/numpybackend/evaluator.py
+++ b/yakof/numpybackend/evaluator.py
@@ -181,7 +181,7 @@ def evaluate(
     if isinstance(node, graph.multi_clause_where):
         conditions = []
         values = []
-        for cond, value in node.clauses[:-1]:
+        for cond, value in node.clauses:  # No slice - process all clauses
             conditions.append(evaluate(cond, bindings, cache))
             values.append(evaluate(value, bindings, cache))
         default = evaluate(node.default_value, bindings, cache)


### PR DESCRIPTION
This diff adds unit tests for `numpybackend.evaluator`. We aim to add enough test cases to have good coverage as well as to ensure that operations performed using the `evaluator` produce the same result we'd get when using `numpy`.

While there, rewrite `numpybackend.py` to use explicit state+caching and to separate caching-aware evaluate and caching-agnostic evaluate. These two improvements were written to increase confidence that code is WAI considering the available tests we have written and included in this pull request.

While there, ignore coverage related files.

While there, fix a bug in the `multi_clause_where` implementation discovered thanks to unit tests.

