### PR TITLE
feat(yakof.frontend): add the abstract module

### DIFF
--- a/tests/frontend/test_abstract.py
+++ b/tests/frontend/test_abstract.py
@@ -289,3 +289,106 @@ def test_tensor_space_method_consistency():
     assert isinstance(not_method.node, graph.UnaryOp)
     assert not_op.node.node is x.node
     assert not_method.node.node is x.node
+
+
+def test_tensor_name_property():
+    """Test tensor name getter and setter."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+
+    # Test initial name
+    assert x.name == "x"
+
+    # Test name setter
+    x.name = "renamed"
+    assert x.name == "renamed"
+    assert x.node.name == "renamed"  # Verify it propagates to node
+
+
+def test_tensor_reverse_operations():
+    """Test reverse arithmetic and logical operations."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+
+    # Test reverse subtraction (other - x)
+    rsub = 2.0 - x
+    assert isinstance(rsub.node, graph.subtract)
+    assert isinstance(rsub.node.left, graph.constant)
+    assert rsub.node.left.value == 2.0
+    assert rsub.node.right is x.node
+
+    # Test reverse multiplication (other * x)
+    rmul = 2.0 * x
+    assert isinstance(rmul.node, graph.multiply)
+    assert isinstance(rmul.node.left, graph.constant)
+    assert rmul.node.left.value == 2.0
+    assert rmul.node.right is x.node
+
+    # Test reverse division (other / x)
+    rdiv = 2.0 / x
+    assert isinstance(rdiv.node, graph.divide)
+    assert isinstance(rdiv.node.left, graph.constant)
+    assert rdiv.node.left.value == 2.0
+    assert rdiv.node.right is x.node
+
+    # Test reverse logical AND (other & x)
+    rand = True & x
+    assert isinstance(rand.node, graph.logical_and)
+    assert isinstance(rand.node.left, graph.constant)
+    assert rand.node.left.value is True
+    assert rand.node.right is x.node
+
+    # Test reverse logical OR (other | x)
+    ror = True | x
+    assert isinstance(ror.node, graph.logical_or)
+    assert isinstance(ror.node.left, graph.constant)
+    assert ror.node.left.value is True
+    assert ror.node.right is x.node
+
+    # Test reverse logical XOR (other ^ x)
+    rxor = True ^ x
+    assert isinstance(rxor.node, graph.logical_xor)
+    assert isinstance(rxor.node.left, graph.constant)
+    assert rxor.node.left.value is True
+    assert rxor.node.right is x.node
+
+
+def test_tensor_reverse_operations_with_tensors():
+    """Test reverse operations with tensors instead of scalars."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+    y = space.placeholder("y")
+
+    # Test reverse subtraction (y - x)
+    rsub = y - x
+    assert isinstance(rsub.node, graph.subtract)
+    assert rsub.node.left is y.node
+    assert rsub.node.right is x.node
+
+    # Test reverse multiplication (y * x)
+    rmul = y * x
+    assert isinstance(rmul.node, graph.multiply)
+    assert rmul.node.left is y.node
+    assert rmul.node.right is x.node
+
+    # Test reverse division (y / x)
+    rdiv = y / x
+    assert isinstance(rdiv.node, graph.divide)
+    assert rdiv.node.left is y.node
+    assert rdiv.node.right is x.node
+
+    # Test reverse logical operations
+    rand = y & x
+    assert isinstance(rand.node, graph.logical_and)
+    assert rand.node.left is y.node
+    assert rand.node.right is x.node
+
+    ror = y | x
+    assert isinstance(ror.node, graph.logical_or)
+    assert ror.node.left is y.node
+    assert ror.node.right is x.node
+
+    rxor = y ^ x
+    assert isinstance(rxor.node, graph.logical_xor)
+    assert rxor.node.left is y.node
+    assert rxor.node.right is x.node

--- a/tests/frontend/test_abstract.py
+++ b/tests/frontend/test_abstract.py
@@ -9,8 +9,6 @@ from yakof.frontend import abstract, graph
 class DummyBasis:
     """Dummy basis type for testing."""
 
-    pass
-
 
 def test_tensor_creation():
     """Test basic tensor creation and properties."""

--- a/tests/frontend/test_abstract.py
+++ b/tests/frontend/test_abstract.py
@@ -1,0 +1,291 @@
+"""Tests for the yakof.frontend.abstract module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from yakof.frontend import abstract, graph
+
+
+class DummyBasis:
+    """Dummy basis type for testing."""
+
+    pass
+
+
+def test_tensor_creation():
+    """Test basic tensor creation and properties."""
+    space = abstract.TensorSpace[DummyBasis]()
+
+    # Test placeholder creation
+    x = space.placeholder("x", 1.0)
+    assert x.name == "x"
+    assert isinstance(x.node, graph.placeholder)
+    assert x.node.default_value == 1.0
+
+    # Test constant creation
+    c = space.constant(2.0, "c")
+    assert c.name == "c"
+    assert isinstance(c.node, graph.constant)
+    assert c.node.value == 2.0
+
+
+def test_tensor_arithmetic():
+    """Test arithmetic operations between tensors."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+    y = space.placeholder("y")
+    c = space.constant(2.0)
+
+    # Test operator overloading
+    add1 = x + y
+    assert isinstance(add1.node, graph.add)
+    assert add1.node.left is x.node
+    assert add1.node.right is y.node
+
+    # Test scalar operations
+    add2 = x + 2.0
+    assert isinstance(add2.node, graph.add)
+    assert add2.node.left is x.node
+    assert isinstance(add2.node.right, graph.constant)
+
+    # Test reverse operations
+    add3 = 2.0 + x
+    assert isinstance(add3.node, graph.add)
+    assert isinstance(add3.node.left, graph.constant)
+    assert add3.node.right is x.node
+
+    # Test other arithmetic operations
+    sub = x - y
+    assert isinstance(sub.node, graph.subtract)
+    mul = x * y
+    assert isinstance(mul.node, graph.multiply)
+    div = x / y
+    assert isinstance(div.node, graph.divide)
+
+
+def test_tensor_comparisons():
+    """Test comparison operations between tensors."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+    y = space.placeholder("y")
+
+    # Test all comparison operators
+    eq = x == y
+    assert isinstance(eq.node, graph.equal)
+    ne = x != y
+    assert isinstance(ne.node, graph.not_equal)
+    lt = x < y
+    assert isinstance(lt.node, graph.less)
+    le = x <= y
+    assert isinstance(le.node, graph.less_equal)
+    gt = x > y
+    assert isinstance(gt.node, graph.greater)
+    ge = x >= y
+    assert isinstance(ge.node, graph.greater_equal)
+
+
+def test_tensor_logical():
+    """Test logical operations between tensors."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+    y = space.placeholder("y")
+
+    # Test logical operators
+    and_op = x & y
+    assert isinstance(and_op.node, graph.logical_and)
+    or_op = x | y
+    assert isinstance(or_op.node, graph.logical_or)
+    xor_op = x ^ y
+    assert isinstance(xor_op.node, graph.logical_xor)
+    not_op = ~x
+    assert isinstance(not_op.node, graph.logical_not)
+
+
+def test_tensor_math():
+    """Test mathematical operations on tensors."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+    y = space.placeholder("y")
+
+    # Test math operations
+    exp = space.exp(x)
+    assert isinstance(exp.node, graph.exp)
+    log = space.log(x)
+    assert isinstance(log.node, graph.log)
+    power = space.power(x, y)
+    assert isinstance(power.node, graph.power)
+    maximum = space.maximum(x, y)
+    assert isinstance(maximum.node, graph.maximum)
+
+
+def test_tensor_conditional():
+    """Test conditional operations on tensors."""
+    space = abstract.TensorSpace[DummyBasis]()
+    cond = space.placeholder("cond")
+    x = space.placeholder("x")
+    y = space.placeholder("y")
+
+    # Test where operation
+    where = space.where(cond, x, y)
+    assert isinstance(where.node, graph.where)
+    assert where.node.condition is cond.node
+    assert where.node.then is x.node
+    assert where.node.otherwise is y.node
+
+    # Test multi_clause_where
+    clauses = [(cond, x)]
+    multi_where = space.multi_clause_where(clauses, y)
+    assert isinstance(multi_where.node, graph.multi_clause_where)
+    assert multi_where.node.clauses[0][0] is cond.node
+    assert multi_where.node.clauses[0][1] is x.node
+    assert multi_where.node.default_value is y.node
+
+
+def test_tensor_distributions():
+    """Test probability distribution operations on tensors."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+    loc = space.placeholder("loc")
+    scale = space.placeholder("scale")
+
+    # Test normal CDF
+    normal = space.normal_cdf(x, loc, scale)
+    assert isinstance(normal.node, graph.normal_cdf)
+    assert normal.node.x is x.node
+    assert normal.node.loc is loc.node
+    assert normal.node.scale is scale.node
+
+    # Test uniform CDF
+    uniform = space.uniform_cdf(x, loc, scale)
+    assert isinstance(uniform.node, graph.uniform_cdf)
+    assert uniform.node.x is x.node
+    assert uniform.node.loc is loc.node
+    assert uniform.node.scale is scale.node
+
+
+def test_tensor_debug():
+    """Test debug operations on tensors."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+
+    # Test tracepoint
+    traced = space.tracepoint(x)
+    assert traced.node.flags & graph.NODE_FLAG_TRACE
+    assert traced.node is x.node
+
+    # Test breakpoint
+    broken = space.breakpoint(x)
+    assert broken.node.flags & graph.NODE_FLAG_BREAK
+    assert broken.node.flags & graph.NODE_FLAG_TRACE
+    assert broken.node is x.node
+
+
+def test_tensor_identity():
+    """Test tensor identity and hashing behavior."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+    y = space.placeholder("x")  # Same name, different tensor
+
+    # Test identity
+    assert x is not y
+    assert hash(x) != hash(y)
+
+    # Test dictionary usage
+    d = {x: 1, y: 2}
+    assert len(d) == 2
+    assert d[x] == 1
+    assert d[y] == 2
+
+
+def test_tensor_space_method_consistency():
+    """Test that TensorSpace methods are consistent with Tensor operators."""
+    space = abstract.TensorSpace[DummyBasis]()
+    x = space.placeholder("x")
+    y = space.placeholder("y")
+
+    # Compare operator results with method results for binary operations
+    add_op = x + y
+    add_method = space.add(x, y)
+    assert isinstance(add_op.node, graph.BinaryOp)
+    assert isinstance(add_method.node, graph.BinaryOp)
+    assert add_op.node.left is add_method.node.left
+
+    sub_op = x - y
+    sub_method = space.subtract(x, y)
+    assert isinstance(sub_op.node, graph.BinaryOp)
+    assert isinstance(sub_method.node, graph.BinaryOp)
+    assert sub_op.node.left is sub_method.node.left
+
+    mul_op = x * y
+    mul_method = space.multiply(x, y)
+    assert isinstance(mul_op.node, graph.BinaryOp)
+    assert isinstance(mul_method.node, graph.BinaryOp)
+    assert mul_op.node.left is mul_method.node.left
+
+    div_op = x / y
+    div_method = space.divide(x, y)
+    assert isinstance(div_op.node, graph.BinaryOp)
+    assert isinstance(div_method.node, graph.BinaryOp)
+    assert div_op.node.left is div_method.node.left
+
+    eq_op = x == y
+    eq_method = space.equal(x, y)
+    assert isinstance(eq_op.node, graph.BinaryOp)
+    assert isinstance(eq_method.node, graph.BinaryOp)
+    assert eq_op.node.left is eq_method.node.left
+
+    ne_op = x != y
+    ne_method = space.not_equal(x, y)
+    assert isinstance(ne_op.node, graph.BinaryOp)
+    assert isinstance(ne_method.node, graph.BinaryOp)
+    assert ne_op.node.left is ne_method.node.left
+
+    lt_op = x < y
+    lt_method = space.less(x, y)
+    assert isinstance(lt_op.node, graph.BinaryOp)
+    assert isinstance(lt_method.node, graph.BinaryOp)
+    assert lt_op.node.left is lt_method.node.left
+
+    le_op = x <= y
+    le_method = space.less_equal(x, y)
+    assert isinstance(le_op.node, graph.BinaryOp)
+    assert isinstance(le_method.node, graph.BinaryOp)
+    assert le_op.node.left is le_method.node.left
+
+    gt_op = x > y
+    gt_method = space.greater(x, y)
+    assert isinstance(gt_op.node, graph.BinaryOp)
+    assert isinstance(gt_method.node, graph.BinaryOp)
+    assert gt_op.node.left is gt_method.node.left
+
+    ge_op = x >= y
+    ge_method = space.greater_equal(x, y)
+    assert isinstance(ge_op.node, graph.BinaryOp)
+    assert isinstance(ge_method.node, graph.BinaryOp)
+    assert ge_op.node.left is ge_method.node.left
+
+    and_op = x & y
+    and_method = space.logical_and(x, y)
+    assert isinstance(and_op.node, graph.BinaryOp)
+    assert isinstance(and_method.node, graph.BinaryOp)
+    assert and_op.node.left is and_method.node.left
+
+    or_op = x | y
+    or_method = space.logical_or(x, y)
+    assert isinstance(or_op.node, graph.BinaryOp)
+    assert isinstance(or_method.node, graph.BinaryOp)
+    assert or_op.node.left is or_method.node.left
+
+    xor_op = x ^ y
+    xor_method = space.logical_xor(x, y)
+    assert isinstance(xor_op.node, graph.BinaryOp)
+    assert isinstance(xor_method.node, graph.BinaryOp)
+    assert xor_op.node.left is xor_method.node.left
+
+    # For unary operations, check type and operand instead of identity
+    not_op = ~x
+    not_method = space.logical_not(x)
+    assert isinstance(not_op.node, graph.UnaryOp)
+    assert isinstance(not_method.node, graph.UnaryOp)
+    assert not_op.node.node is x.node
+    assert not_method.node.node is x.node

--- a/yakof/frontend/abstract.py
+++ b/yakof/frontend/abstract.py
@@ -24,6 +24,7 @@ This package uses 'tensor' in the computational sense (i.e., multidimensional
 arrays) while borrowing mathematical concepts like bases and vector spaces
 to provide a structured way to handle transformations between different
 dimensional spaces.
+
 While not strictly adhering to mathematical tensor theory, this approach
 provides a practical framework for engineering computations.
 

--- a/yakof/frontend/abstract.py
+++ b/yakof/frontend/abstract.py
@@ -18,8 +18,44 @@ The module provides these abstractions:
 The type parameters ensure that operations between tensors are only possible
 when they share the same context and basis.
 
-Type System Design
-------------------
+On mathematical terminology
+---------------------------
+This package uses 'tensor' in the computational sense (i.e., multidimensional
+arrays) while borrowing mathematical concepts like bases and vector spaces
+to provide a structured way to handle transformations between different
+dimensional spaces.
+While not strictly adhering to mathematical tensor theory, this approach
+provides a practical framework for engineering computations.
+
+Categorical Structure
+---------------------
+
+The module implements a categorical structure where:
+
+1. Objects are tensor spaces (TensorSpace[B])
+2. Morphisms are structure-preserving maps between tensor spaces
+3. Endomorphisms are operations within a tensor space that preserve its structure
+
+Key categorical properties:
+
+1. Identity: Each tensor space has identity operations
+2. Composition: Operations can be composed while preserving types
+3. Associativity: Operation composition is associative
+
+This categorical view informs key design decisions:
+
+1. Operations that change tensor shape/basis (like reduce_sum or expand_dims)
+   are not methods of TensorSpace as they are morphisms between different
+   spaces rather than endomorphisms within a space.
+
+2. Operations that preserve tensor structure (like add or multiply) are
+   methods of TensorSpace as they are endomorphisms within the same space.
+
+3. The type system enforces these categorical constraints at compile time,
+   ensuring mathematical correctness.
+
+Type System Implementation
+--------------------------
 
 The type system uses generics to enforce:
 
@@ -31,15 +67,6 @@ The type system uses generics to enforce:
    - Clear distinction between different tensor spaces
 
 This design enables catching errors at compile time.
-
-On mathematical terminology
----------------------------
-This package uses 'tensor' in the computational sense (i.e., multidimensional
-arrays) while borrowing mathematical concepts like bases and vector spaces
-to provide a structured way to handle transformations between different
-dimensional spaces.
-While not strictly adhering to mathematical tensor theory, this approach
-provides a practical framework for engineering computations.
 """
 
 # SPDX-License-Identifier: Apache-2.0

--- a/yakof/frontend/abstract.py
+++ b/yakof/frontend/abstract.py
@@ -1,0 +1,308 @@
+"""
+Abstract Tensor Operations
+==========================
+
+This modules defines tensors spaces, tensors within spaces, and mapping
+operations to convert tensors across spaces. It builds on top of the
+computation graph (yakof.frontend.graph) to provide a type-safe interface
+for working with tensors in different spaces.
+
+The module provides these abstractions:
+
+1. TensorSpace[B]: A space of tensors with a given basis.
+   Provides mathematical operations such as exp, log, and power.
+
+2. Tensor[B]: A tensor with associated basis vectors.
+   Supports arithmetic, comparison, and logical operations.
+
+The type parameters ensure that operations between tensors are only possible
+when they share the same context and basis.
+
+Type System Design
+------------------
+
+The type system uses generics to enforce:
+
+1. Basis compatibility:
+   - Operations only between tensors with same basis
+   - Compile-time detection of dimension mismatches
+
+2. Context preservation:
+   - Clear distinction between different tensor spaces
+
+This design enables catching errors at compile time.
+
+On mathematical terminology
+---------------------------
+This package uses 'tensor' in the computational sense (i.e., multidimensional
+arrays) while borrowing mathematical concepts like bases and vector spaces
+to provide a structured way to handle transformations between different
+dimensional spaces.
+While not strictly adhering to mathematical tensor theory, this approach
+provides a practical framework for engineering computations.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from . import graph
+
+
+class _ensure_tensor[B]:
+    def __call__(self, t: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        if isinstance(t, graph.Scalar):
+            t = Tensor[B](graph.constant(t))
+        return t
+
+
+class Tensor[B]:
+    """A tensor with associated basis vectors.
+
+    Type Parameters:
+        B: Type of the basis vectors.
+    """
+
+    def __init__(self, node: graph.Node) -> None:
+        self.node = node
+
+    @property
+    def name(self) -> str:
+        return self.node.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self.node.name = value
+
+    def __hash__(self) -> int:
+        return hash(self.node)  # hashing by identity
+
+    # Arithmetic operators
+    def __add__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.add(self.node, _ensure_tensor[B]()(other).node))
+
+    def __radd__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.add(_ensure_tensor[B]()(other).node, self.node))
+
+    def __sub__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.subtract(self.node, _ensure_tensor[B]()(other).node))
+
+    def __rsub__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.subtract(_ensure_tensor[B]()(other).node, self.node))
+
+    def __mul__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.multiply(self.node, _ensure_tensor[B]()(other).node))
+
+    def __rmul__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.multiply(_ensure_tensor[B]()(other).node, self.node))
+
+    def __truediv__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.divide(self.node, _ensure_tensor[B]()(other).node))
+
+    def __rtruediv__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.divide(_ensure_tensor[B]()(other).node, self.node))
+
+    # Comparison operators
+    def __eq__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:  # type: ignore
+        return type(self)(graph.equal(self.node, _ensure_tensor[B]()(other).node))
+
+    def __ne__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:  # type: ignore
+        return type(self)(graph.not_equal(self.node, _ensure_tensor[B]()(other).node))
+
+    def __lt__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.less(self.node, _ensure_tensor[B]()(other).node))
+
+    def __le__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.less_equal(self.node, _ensure_tensor[B]()(other).node))
+
+    def __gt__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.greater(self.node, _ensure_tensor[B]()(other).node))
+
+    def __ge__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(
+            graph.greater_equal(self.node, _ensure_tensor[B]()(other).node)
+        )
+
+    # Logical operators
+    def __and__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.logical_and(self.node, _ensure_tensor[B]()(other).node))
+
+    def __rand__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.logical_and(_ensure_tensor[B]()(other).node, self.node))
+
+    def __or__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.logical_or(self.node, _ensure_tensor[B]()(other).node))
+
+    def __ror__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.logical_or(_ensure_tensor[B]()(other).node, self.node))
+
+    def __xor__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.logical_xor(self.node, _ensure_tensor[B]()(other).node))
+
+    def __rxor__(self, other: Tensor[B] | graph.Scalar) -> Tensor[B]:
+        return type(self)(graph.logical_xor(_ensure_tensor[B]()(other).node, self.node))
+
+    def __invert__(self) -> Tensor[B]:
+        return type(self)(graph.logical_not(self.node))
+
+
+class TensorSpace[B]:
+    """A space of tensors with associated basis vectors.
+
+    Type Parameters:
+        B: Type of the basis vectors.
+    """
+
+    def placeholder(
+        self,
+        name: str = "",
+        default_value: graph.Scalar | None = None,
+    ) -> Tensor[B]:
+        """Creates a placeholder tensor.
+
+        The name parameter is optional to allow using autonaming.context():
+
+            >>> with autonaming.context():
+            ...     x = space.placeholder()  # automatically named 'x'
+
+        But must be explicitly provided otherwise:
+
+            >>> y = space.placeholder("y")  # explicitly named
+
+        Regardless, a placeholder with no name cannot be used in the graph.
+        """
+        return Tensor[B](graph.placeholder(name, default_value))
+
+    def constant(self, value: graph.Scalar, name: str = "") -> Tensor[B]:
+        """Creates a constant tensor."""
+        return Tensor[B](graph.constant(value, name))
+
+    def exp(self, t: Tensor[B]) -> Tensor[B]:
+        """Compute the exponential of a tensor."""
+        return type(t)(graph.exp(t.node))
+
+    def power(self, t: Tensor[B], exp: Tensor[B]) -> Tensor[B]:
+        """Raise tensor to the power of another tensor."""
+        return type(t)(graph.power(t.node, exp.node))
+
+    def log(self, t: Tensor[B]) -> Tensor[B]:
+        """Compute the natural logarithm of a tensor."""
+        return type(t)(graph.log(t.node))
+
+    def maximum(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Compute element-wise maximum of two tensors."""
+        return type(t1)(graph.maximum(t1.node, t2.node))
+
+    def where[
+        C
+    ](self, cond: Tensor[C], then: Tensor[B], otherwise: Tensor[B]) -> Tensor[B]:
+        """Select elements based on condition."""
+        return type(then)(graph.where(cond.node, then.node, otherwise.node))
+
+    def multi_clause_where[
+        C
+    ](
+        self,
+        clauses: Sequence[tuple[Tensor[C], Tensor[B]]],
+        default_value: Tensor[B] | graph.Scalar,
+    ) -> Tensor[B]:
+        """Select elements based on multiple conditions."""
+        return Tensor[B](
+            graph.multi_clause_where(
+                clauses=[(cond.node, value.node) for cond, value in clauses],
+                default_value=_ensure_tensor[B]()(default_value).node,
+            )
+        )
+
+    def normal_cdf(
+        self,
+        x: Tensor[B],
+        loc: Tensor[B] | graph.Scalar = 0.0,
+        scale: Tensor[B] | graph.Scalar = 1.0,
+    ) -> Tensor[B]:
+        """Compute normal distribution CDF."""
+        return Tensor[B](
+            graph.normal_cdf(
+                x.node, _ensure_tensor[B]()(loc).node, _ensure_tensor[B]()(scale).node
+            )
+        )
+
+    def uniform_cdf(
+        self,
+        x: Tensor[B],
+        loc: Tensor[B] | graph.Scalar = 0.0,
+        scale: Tensor[B] | graph.Scalar = 1.0,
+    ) -> Tensor[B]:
+        """Compute uniform distribution CDF."""
+        return Tensor[B](
+            graph.uniform_cdf(
+                x.node, _ensure_tensor[B]()(loc).node, _ensure_tensor[B]()(scale).node
+            )
+        )
+
+    def tracepoint(self, t: Tensor[B]) -> Tensor[B]:
+        """Inserts a tracepoint for the current tensor inside the computation graph."""
+        return Tensor[B](graph.tracepoint(t.node))
+
+    def breakpoint(self, t: Tensor[B]) -> Tensor[B]:
+        """Inserts a breakpoint for the current tensor inside the computation graph."""
+        return Tensor[B](graph.breakpoint(t.node))
+
+    # Additional shape/structure preserving operations
+    def add(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise addition of two tensors."""
+        return type(t1)(graph.add(t1.node, t2.node))
+
+    def subtract(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise subtraction of two tensors."""
+        return type(t1)(graph.subtract(t1.node, t2.node))
+
+    def multiply(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise multiplication of two tensors."""
+        return type(t1)(graph.multiply(t1.node, t2.node))
+
+    def divide(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise division of two tensors."""
+        return type(t1)(graph.divide(t1.node, t2.node))
+
+    def equal(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise equality comparison of two tensors."""
+        return type(t1)(graph.equal(t1.node, t2.node))
+
+    def not_equal(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise inequality comparison of two tensors."""
+        return type(t1)(graph.not_equal(t1.node, t2.node))
+
+    def less(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise less-than comparison of two tensors."""
+        return type(t1)(graph.less(t1.node, t2.node))
+
+    def less_equal(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise less-than-or-equal comparison of two tensors."""
+        return type(t1)(graph.less_equal(t1.node, t2.node))
+
+    def greater(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise greater-than comparison of two tensors."""
+        return type(t1)(graph.greater(t1.node, t2.node))
+
+    def greater_equal(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise greater-than-or-equal comparison of two tensors."""
+        return type(t1)(graph.greater_equal(t1.node, t2.node))
+
+    def logical_and(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise logical AND of two tensors."""
+        return type(t1)(graph.logical_and(t1.node, t2.node))
+
+    def logical_or(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise logical OR of two tensors."""
+        return type(t1)(graph.logical_or(t1.node, t2.node))
+
+    def logical_xor(self, t1: Tensor[B], t2: Tensor[B]) -> Tensor[B]:
+        """Element-wise logical XOR of two tensors."""
+        return type(t1)(graph.logical_xor(t1.node, t2.node))
+
+    def logical_not(self, t: Tensor[B]) -> Tensor[B]:
+        """Element-wise logical NOT of a tensor."""
+        return type(t)(graph.logical_not(t.node))


### PR DESCRIPTION
This module adds abstract support for creating tensors (in the engineering sense) and tensor spaces (ditto) using specific bases of the possible vector spaces. We use generics to do this.

The result is that we build a category, `TensorSpace[B]`, which implements endomorphisms, and we still need to build other abstractions to implement the remaining morphisms between spaces.

The `Tensor[B]` is a convenience wrapper for `graph.Node` that, not only binds `Tensor[B]` to a basis `B`, but also implements convenience infix operations so that we could write stuff like `a + b`.