### PR TITLE
feat(frontend): add support for autoname tensors

### DIFF
--- a/tests/frontend/test_autonaming.py
+++ b/tests/frontend/test_autonaming.py
@@ -97,8 +97,10 @@ def test_reassignment():
     """Test naming behavior with variable reassignment."""
     with autonaming.context():
         x = NameableObject()
-        x = NameableObject()  # Reassignment
-    assert x.name == "x"  # Last assignment should be named
+    with autonaming.context():
+        y = x
+    assert x.name == "x"
+    assert y.name == "x"
 
 
 def test_frame_behavior():

--- a/tests/frontend/test_autonaming.py
+++ b/tests/frontend/test_autonaming.py
@@ -1,0 +1,155 @@
+"""Tests for the yakof.frontend.autonaming module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import logging
+import pytest
+
+from yakof.frontend import autonaming
+
+
+class NameableObject:
+    """Test class implementing the Nameable protocol."""
+
+    def __init__(self, initial_name: str = "") -> None:
+        self._name = initial_name
+
+    def implements_namer(self) -> None:
+        """Part of the autonaming.Nameable protocol."""
+
+    @property
+    def name(self) -> str:
+        """Part of the autonaming.Nameable protocol."""
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """Part of the autonaming.Nameable protocol."""
+        self._name = value
+
+
+class HasNameButNotNameable:
+    """Test class with name attribute but not implementing Nameable protocol."""
+
+    def __init__(self) -> None:
+        self.name = ""
+
+
+def test_basic_naming():
+    """Test basic automatic naming functionality."""
+    with autonaming.context():
+        x = NameableObject()
+        y = NameableObject()
+    assert x.name == "x"
+    assert y.name == "y"
+
+
+def test_respect_existing_names():
+    """Test that existing names are not overwritten."""
+    with autonaming.context():
+        x = NameableObject("existing")
+        y = NameableObject()
+    assert x.name == "existing"  # Preserved
+    assert y.name == "y"  # Auto-named
+
+
+def test_non_nameable_objects():
+    """Test that non-Nameable objects are ignored."""
+    with autonaming.context():
+        x = NameableObject()
+        y = HasNameButNotNameable()
+        z = "not_an_object"
+    assert x.name == "x"  # Should be named
+    assert y.name == ""  # Should be untouched
+
+
+def test_nested_contexts():
+    """Test that nested naming contexts work correctly."""
+    with autonaming.context():
+        x = NameableObject()
+        with autonaming.context():
+            y = NameableObject()
+    assert x.name == "x"
+    assert y.name == "y"
+
+
+def test_multiple_variables():
+    """Test naming multiple variables in complex scenarios."""
+    with autonaming.context():
+        x = NameableObject()
+        y = [NameableObject() for _ in range(3)]  # List of nameables
+        z = {"key": NameableObject()}  # Dict with nameable
+    assert x.name == "x"
+    assert y[0].name == ""  # List elements shouldn't be auto-named
+    assert z["key"].name == ""  # Dict values shouldn't be auto-named
+
+
+def test_protocol_checking():
+    """Test runtime protocol checking behavior."""
+    assert isinstance(NameableObject(), autonaming.Nameable)
+    assert not isinstance(HasNameButNotNameable(), autonaming.Nameable)
+    assert not isinstance("string", autonaming.Nameable)
+
+
+def test_reassignment():
+    """Test naming behavior with variable reassignment."""
+    with autonaming.context():
+        x = NameableObject()
+        x = NameableObject()  # Reassignment
+    assert x.name == "x"  # Last assignment should be named
+
+
+def test_frame_behavior():
+    """Test basic frame behavior."""
+    with autonaming.context():
+        x = NameableObject()  # Should be named
+
+        def nested():
+            y = NameableObject()  # Should NOT be named
+            return y
+
+        z = nested()  # Should be named when assigned here
+
+    assert x.name == "x"
+    assert z.name == "z"
+
+
+def test_naming_warnings(caplog):
+    """Test warning behavior for multiple names."""
+    caplog.set_level(logging.WARNING)
+
+    with autonaming.context():
+        x = NameableObject()
+        y = x  # Should trigger warning
+
+    assert len(caplog.records) == 3
+    assert "attempting to rename" in caplog.records[0].message
+    assert "debugging code will use" in caplog.records[1].message
+    assert "consider adjusting your code" in caplog.records[2].message
+    assert x.name == y.name  # Same object has same name
+
+
+def test_comprehension_edge_cases():
+    """Test basic comprehension behavior."""
+    with autonaming.context():
+        xs = [NameableObject() for _ in range(2)]
+        first = xs[0]  # Should be named
+
+    assert first.name == "first"
+    assert xs[1].name == ""  # Not directly named
+
+
+def test_exception_handling():
+    """Test naming behavior when exceptions occur."""
+    obj = NameableObject()
+
+    try:
+        with autonaming.context():
+            x = obj
+            raise ValueError("test error")
+    except ValueError:
+        pass
+
+    assert obj.name == ""  # Should not be named due to exception

--- a/yakof/frontend/abstract.py
+++ b/yakof/frontend/abstract.py
@@ -96,12 +96,17 @@ class Tensor[B]:
     def __init__(self, node: graph.Node) -> None:
         self.node = node
 
+    def implements_namer(self) -> None:
+        """This method is part of the autonaming.Namer protocol"""
+
     @property
     def name(self) -> str:
+        """This method is part of the autonaming.Namer protocol"""
         return self.node.name
 
     @name.setter
     def name(self, value: str) -> None:
+        """This method is part of the autonaming.Namer protocol"""
         self.node.name = value
 
     def __hash__(self) -> int:

--- a/yakof/frontend/autonaming.py
+++ b/yakof/frontend/autonaming.py
@@ -17,7 +17,7 @@ Here's a simple example:
     ...     z = x + y                # named 'z'
 
 Implementation Notes
-------------------
+--------------------
 
 The context manager tracks variable assignments in the current scope and automatically
 names unnamed objects that implement the Nameable protocol.
@@ -74,7 +74,7 @@ code. For reliable debugging, avoid assigning multiple names to the same
 tensor.
 
 Best Practices
--------------
+--------------
 
 DO:
 - Use meaningful, unique names for tensors

--- a/yakof/frontend/autonaming.py
+++ b/yakof/frontend/autonaming.py
@@ -158,8 +158,12 @@ class context:
             if not isinstance(var, Nameable):
                 continue
             if var.name:
-                logging.warning(f"autonaming: attempting to rename {var.name} to {name}")
+                logging.warning(
+                    f"autonaming: attempting to rename {var.name} to {name}"
+                )
                 logging.warning(f"autonaming: debugging code will use {var.name}")
-                logging.warning(f"autonaming: consider adjusting your code to avoid aliasing tensors")
+                logging.warning(
+                    f"autonaming: consider adjusting your code to avoid aliasing tensors"
+                )
                 continue
             var.name = name

--- a/yakof/frontend/autonaming.py
+++ b/yakof/frontend/autonaming.py
@@ -1,0 +1,165 @@
+"""
+Automatic Naming
+================
+
+Provides a context manager to automatically name tensors for debugging purposes.
+
+Basic Usage
+-----------
+
+Here's a simple example:
+
+    >>> from yakof.frontend import abstract, autonaming
+    >>> space = abstract.TensorSpace(abstract.bases.X)
+    >>> with autonaming.context():
+    ...     x = space.placeholder()  # named 'x'
+    ...     y = space.placeholder()  # named 'y'
+    ...     z = x + y                # named 'z'
+
+Implementation Notes
+------------------
+
+The context manager tracks variable assignments in the current scope and automatically
+names unnamed objects that implement the Nameable protocol.
+
+Supported Patterns
+~~~~~~~~~~~~~~~~~~
+
+1. Direct assignments in the context frame:
+
+    >>> with autonaming.context():
+    ...     x = space.placeholder()  # named 'x'
+    ...     y = make_placeholder()   # named 'y'
+
+2. Operations on named tensors:
+
+    >>> with autonaming.context():
+    ...     x = space.placeholder()  # named 'x'
+    ...     y = x + 1               # named 'y'
+
+Unsupported Patterns
+~~~~~~~~~~~~~~~~~~~~
+
+1. Objects created in comprehensions:
+
+    >>> with autonaming.context():
+    ...     tensors = [space.placeholder() for _ in range(3)]  # NOT named
+    ...     x = tensors[0]  # named 'x'
+
+2. Objects created in nested scopes:
+
+    >>> with autonaming.context():
+    ...     def make_tensor():
+    ...         return space.placeholder()  # NOT named
+    ...     x = make_tensor()  # named 'x'
+
+Aliasing and Name Conflicts
+---------------------------
+
+When the same tensor is assigned to multiple names:
+
+    >>> with autonaming.context():
+    ...     x = space.placeholder()  # Gets named 'x'
+    ...     y = x                    # Warning: attempting to rename
+
+The context manager:
+1. Uses the first name it encounters for the tensor
+2. Emits a warning for subsequent naming attempts
+3. Suggests adjusting code to avoid aliasing
+
+Note: The order in which names are processed depends on Python's dictionary
+iteration order. While this is stable within a Python version since 3.7,
+it means the "first" name might not be the one that appears first in your
+code. For reliable debugging, avoid assigning multiple names to the same
+tensor.
+
+Best Practices
+-------------
+
+DO:
+- Use meaningful, unique names for tensors
+- Use the context manager for debugging purposes
+
+DON'T:
+- Rely on specific names/strings for the model logic
+- Assign the same tensor to multiple names
+- Create tensors in comprehensions or nested functions
+"""
+
+from typing import Protocol, runtime_checkable
+
+import inspect
+import logging
+import types
+
+
+@runtime_checkable
+class Nameable(Protocol):
+    """
+    Protocol for objects with name setters and getters.
+
+    Methods:
+        implements_namer: adds extra methods to the expected interface to avoid
+        name setting for objects that do implement name getter/setter but are
+        not designed to work along with the autonaming functionality.
+
+        name: getter for the name of the object.
+
+        name: setter for the name of the object.
+    """
+
+    def implements_namer(self) -> None: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @name.setter
+    def name(self, value: str) -> None: ...
+
+
+class context:
+    """
+    Context manager for automatically assigning names to Nameable objects.
+
+    Assigning multiple names to the same tensor, such as in the following example:
+
+        >>> with autonaming.context():
+        ...     x = space.placeholder()
+        ...     y = x
+
+    will cause one of the two names at ~random to be used when debugging. There
+    is no need to assign multiple names to the same underlying tensor. If you use
+    this coding style, the context will emit a warning, to let you know you are
+    making your own debugging more complicated than needed.
+    """
+
+    def __enter__(self) -> None:
+        cf = inspect.currentframe()
+        assert cf is not None
+        frame = cf.f_back
+        assert frame is not None
+        self._initial_locals = set(frame.f_locals.keys())
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        if exc_type is not None:
+            return  # do nothing if there was an exception
+        cf = inspect.currentframe()
+        assert cf is not None
+        frame = cf.f_back
+        assert frame is not None
+        new_vars = set(frame.f_locals.keys()) - self._initial_locals
+        for name in new_vars:
+            var = frame.f_locals[name]
+            if not isinstance(var, Nameable):
+                continue
+            if var.name:
+                logging.warning(f"autonaming: attempting to rename {var.name} to {name}")
+                logging.warning(f"autonaming: debugging code will use {var.name}")
+                logging.warning(f"autonaming: consider adjusting your code to avoid aliasing tensors")
+                continue
+            var.name = name


### PR DESCRIPTION
This diff adds a context manager that supports automatically assigning names to tensors defined within the context. Automatic naming of tensors should improve the DX. Consider:

```Python
from yakof.frontend import abstract

space = abstract.TensorSpace[X]()
x = space.placeholder(name="x")
y = space.constant(10, name="y")
z = x + y
```

and compare this to:

```Python
from yakof.frontend import abstract, autonaming

space = abstract.TensorSpace[X]()
with autonaming.context():
    x = space.placeholder()
    y = space.constant(10)
    z = x + y
```

The latter snippet has less duplication and one does not need to worry about updating the tensor names in addition to assigning them to variables, and to keep the two in sync.

I spent some time trying to understand and possibly solve the problem of aliasing. At the end of the day, since there is no physical meaning associated to aliasing a tensor name with another name, I decided to just emit a warning.