### PR TITLE
feat(frontend): add support for morphisms

### DIFF
--- a/tests/frontend/test_morphisms.py
+++ b/tests/frontend/test_morphisms.py
@@ -1,0 +1,286 @@
+"""Tests for the yakof.frontend.morphisms module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import numpy as np
+
+from yakof.frontend import abstract, morphisms
+from yakof.numpybackend import evaluator
+
+# Generate axes to makes tests using explicit axes more readable
+x, y, z, u = morphisms.generate_canonical_axes(4)
+
+
+# Define simple basis classes for testing
+class X:
+    axes = (x,)
+
+
+class Y:
+    axes = (y,)
+
+
+class Z:
+    axes = (z,)
+
+
+class U:
+    axes = (u,)
+
+
+class XY:
+    axes = (x, y)
+
+
+class XZ:
+    axes = (x, z)
+
+
+class XU:
+    axes = (x, u)
+
+
+class YZ:
+    axes = (y, z)
+
+
+class YU:
+    axes = (y, u)
+
+
+class ZU:
+    axes = (z, u)
+
+
+class XYZU:
+    axes = (x, y, z, u)
+
+
+def test_generate_canonical_bases():
+    assert morphisms.generate_canonical_axes(3) == (1000, 1001, 1002)
+    assert morphisms.generate_canonical_axes(5) == (1000, 1001, 1002, 1003, 1004)
+    assert morphisms.generate_canonical_axes(0) == ()
+
+
+def test_axes_expansion_exceptions():
+    # Test source not subset of destination
+    with pytest.raises(ValueError, match="source must be a subset of destination"):
+        morphisms.axes_expansion((z, x), (x, y))
+
+    # Test non-monotonic source
+    with pytest.raises(ValueError, match="source must have monotonic values"):
+        morphisms.axes_expansion((z, x, y), (x, y, z))
+
+    # Test non-monotonic destination
+    with pytest.raises(ValueError, match="dest must have monotonic values"):
+        morphisms.axes_expansion((x,), (z, x, y))
+
+
+def test_axes_projection_exceptions():
+    # Test destination not subset of source
+    with pytest.raises(ValueError, match="destination must be a subset of source"):
+        morphisms.axes_projection((x, y), (x, y, z))
+
+    # Test non-monotonic source
+    with pytest.raises(ValueError, match="source must have monotonic values"):
+        morphisms.axes_projection((z, x, y), (x,))
+
+    # Test non-monotonic destination
+    with pytest.raises(ValueError, match="dest must have monotonic values"):
+        morphisms.axes_projection((x, y, z), (z, x))
+
+
+@pytest.mark.parametrize(
+    "source,dest,expected",
+    [
+        # R¹ -> R² expansions
+        (x, (x, y), 1),  # X -> XY
+        (x, (x, z), 1),  # X -> XZ
+        (x, (x, u), 1),  # X -> XU
+        (y, (x, y), 0),  # Y -> XY
+        (y, (y, z), 1),  # Y -> YZ
+        (y, (y, u), 1),  # Y -> YU
+        (z, (x, z), 0),  # Z -> XZ
+        (z, (y, z), 0),  # Z -> YZ
+        (z, (z, u), 1),  # Z -> ZU
+        (u, (x, u), 0),  # U -> XU
+        (u, (y, u), 0),  # U -> YU
+        (u, (z, u), 0),  # U -> ZU
+        # R¹ -> R³ expansions
+        (x, (x, y, z), (1, 2)),  # X -> XYZ
+        (x, (x, y, u), (1, 2)),  # X -> XYU
+        (x, (x, z, u), (1, 2)),  # X -> XZU
+        (y, (x, y, z), (0, 2)),  # Y -> XYZ
+        (y, (x, y, u), (0, 2)),  # Y -> XYU
+        (y, (y, z, u), (1, 2)),  # Y -> YZU
+        (z, (x, z, u), (0, 2)),  # Z -> XZU
+        (z, (y, z, u), (0, 2)),  # Z -> YZU
+        (u, (x, y, u), (0, 1)),  # U -> XYU
+        (u, (x, z, u), (0, 1)),  # U -> XZU
+        (u, (y, z, u), (0, 1)),  # U -> YZU
+        # R¹ -> R⁴ expansions
+        (x, (x, y, z, u), (1, 2, 3)),  # X -> XYZU
+        (y, (x, y, z, u), (0, 2, 3)),  # Y -> XYZU
+        (z, (x, y, z, u), (0, 1, 3)),  # Z -> XYZU
+        (u, (x, y, z, u), (0, 1, 2)),  # U -> XYZU
+        # R² -> R³ expansions
+        ((x, y), (x, y, z), 2),  # XY -> XYZ
+        ((x, y), (x, y, u), 2),  # XY -> XYU
+        ((x, z), (x, y, z), 1),  # XZ -> XYZ
+        ((x, z), (x, z, u), 2),  # XZ -> XZU
+        ((x, u), (x, y, u), 1),  # XU -> XYU
+        ((x, u), (x, z, u), 1),  # XU -> XZU
+        ((y, z), (x, y, z), 0),  # YZ -> XYZ
+        ((y, z), (y, z, u), 2),  # YZ -> YZU
+        ((y, u), (x, y, u), 0),  # YU -> XYU
+        ((y, u), (y, z, u), 1),  # YU -> YZU
+        ((z, u), (x, z, u), 0),  # ZU -> XZU
+        ((z, u), (y, z, u), 0),  # ZU -> YZU
+        # R² -> R⁴ expansions
+        ((x, y), (x, y, z, u), (2, 3)),  # XY -> XYZU
+        ((x, z), (x, y, z, u), (1, 3)),  # XZ -> XYZU
+        ((x, u), (x, y, z, u), (1, 2)),  # XU -> XYZU
+        ((y, z), (x, y, z, u), (0, 3)),  # YZ -> XYZU
+        ((y, u), (x, y, z, u), (0, 2)),  # YU -> XYZU
+        ((z, u), (x, y, z, u), (0, 1)),  # ZU -> XYZU
+        # R³ -> R⁴ expansions
+        ((x, y, z), (x, y, z, u), 3),  # XYZ -> XYZU
+        ((x, y, u), (x, y, z, u), 2),  # XYU -> XYZU
+        ((x, z, u), (x, y, z, u), 1),  # XZU -> XYZU
+        ((y, z, u), (x, y, z, u), 0),  # YZU -> XYZU
+        # Edge cases
+        ((), (), ()),  # Empty -> Empty
+        ((x,), (x,), ()),  # Single -> Same single
+    ],
+)
+def test_parametrized_expansions(source, dest, expected):
+    assert morphisms.axes_expansion(source, dest) == expected
+
+
+@pytest.mark.parametrize(
+    "source,dest,expected",
+    [
+        # R⁴ -> R³ projections
+        ((x, y, z, u), (x, y, z), 3),  # XYZU -> XYZ
+        ((x, y, z, u), (x, y, u), 2),  # XYZU -> XYU
+        ((x, y, z, u), (x, z, u), 1),  # XYZU -> XZU
+        ((x, y, z, u), (y, z, u), 0),  # XYZU -> YZU
+        # R⁴ -> R² projections
+        ((x, y, z, u), (x, y), (2, 3)),  # XYZU -> XY
+        ((x, y, z, u), (x, z), (1, 3)),  # XYZU -> XZ
+        ((x, y, z, u), (x, u), (1, 2)),  # XYZU -> XU
+        ((x, y, z, u), (y, z), (0, 3)),  # XYZU -> YZ
+        ((x, y, z, u), (y, u), (0, 2)),  # XYZU -> YU
+        ((x, y, z, u), (z, u), (0, 1)),  # XYZU -> ZU
+        # R⁴ -> R¹ projections
+        ((x, y, z, u), x, (1, 2, 3)),  # XYZU -> X
+        ((x, y, z, u), y, (0, 2, 3)),  # XYZU -> Y
+        ((x, y, z, u), z, (0, 1, 3)),  # XYZU -> Z
+        ((x, y, z, u), u, (0, 1, 2)),  # XYZU -> U
+        # R³ -> R² projections
+        ((x, y, z), (x, y), 2),  # XYZ -> XY
+        ((x, y, z), (x, z), 1),  # XYZ -> XZ
+        ((x, y, z), (y, z), 0),  # XYZ -> YZ
+        ((x, y, u), (x, y), 2),  # XYU -> XY
+        ((x, y, u), (x, u), 1),  # XYU -> XU
+        ((x, y, u), (y, u), 0),  # XYU -> YU
+        ((x, z, u), (x, z), 2),  # XZU -> XZ
+        ((x, z, u), (x, u), 1),  # XZU -> XU
+        ((x, z, u), (z, u), 0),  # XZU -> ZU
+        ((y, z, u), (y, z), 2),  # YZU -> YZ
+        ((y, z, u), (y, u), 1),  # YZU -> YU
+        ((y, z, u), (z, u), 0),  # YZU -> ZU
+        # R³ -> R¹ projections
+        ((x, y, z), x, (1, 2)),  # XYZ -> X
+        ((x, y, z), y, (0, 2)),  # XYZ -> Y
+        ((x, y, z), z, (0, 1)),  # XYZ -> Z
+        ((x, y, u), x, (1, 2)),  # XYU -> X
+        ((x, y, u), y, (0, 2)),  # XYU -> Y
+        ((x, y, u), u, (0, 1)),  # XYU -> U
+        ((x, z, u), x, (1, 2)),  # XZU -> X
+        ((x, z, u), z, (0, 2)),  # XZU -> Z
+        ((x, z, u), u, (0, 1)),  # XZU -> U
+        ((y, z, u), y, (1, 2)),  # YZU -> Y
+        ((y, z, u), z, (0, 2)),  # YZU -> Z
+        ((y, z, u), u, (0, 1)),  # YZU -> U
+        # R² -> R¹ projections
+        ((x, y), x, 1),  # XY -> X
+        ((x, y), y, 0),  # XY -> Y
+        ((x, z), x, 1),  # XZ -> X
+        ((x, z), z, 0),  # XZ -> Z
+        ((x, u), x, 1),  # XU -> X
+        ((x, u), u, 0),  # XU -> U
+        ((y, z), y, 1),  # YZ -> Y
+        ((y, z), z, 0),  # YZ -> Z
+        ((y, u), y, 1),  # YU -> Y
+        ((y, u), u, 0),  # YU -> U
+        ((z, u), z, 1),  # ZU -> Z
+        ((z, u), u, 0),  # ZU -> U
+        # Edge cases
+        ((), (), ()),  # Empty -> Empty
+        ((x,), (x,), ()),  # Single -> Same single
+    ],
+)
+def test_parametrized_projections(source, dest, expected):
+    assert morphisms.axes_projection(source, dest) == expected
+
+
+def test_r4_to_r2_projections():
+    # fixture1: (2,2,2,2) array reshaped from [0,1,2,...,15]*100
+    fixture1 = np.arange(16).reshape(2, 2, 2, 2) * 100
+
+    # Test all R⁴->R² projections
+    for source, dest, fixture, axes in [
+        (XYZU, XY, fixture1, (2, 3)),  # Sum over Z and U
+        (XYZU, XZ, fixture1, (1, 3)),  # Sum over Y and U
+        (XYZU, XU, fixture1, (1, 2)),  # Sum over Y and Z
+        (XYZU, YZ, fixture1, (0, 3)),  # Sum over X and U
+        (XYZU, YU, fixture1, (0, 2)),  # Sum over X and Z
+        (XYZU, ZU, fixture1, (0, 1)),  # Sum over X and Y
+    ]:
+        # Create tensors using frontend
+        space_xyzu = abstract.TensorSpace[source]()
+        t = space_xyzu.placeholder("t")
+        project = morphisms.ProjectUsingSum(source, dest)
+        result = project(t)
+
+        # Direct numpy projection using explicitly specified axes
+        expected = np.sum(fixture, axis=axes)
+
+        # Compare results
+        actual = evaluator.evaluate(
+            result.node, evaluator.StateWithoutCache({"t": fixture})
+        )
+        np.testing.assert_array_equal(actual, expected)
+
+
+def test_r2_to_r4_expansions():
+    # fixture1: (2,2) array reshaped from [0,1,2,3]
+    fixture1 = np.arange(4).reshape(2, 2)
+
+    # Test all R²->R⁴ expansions
+    for source, dest, fixture, axes in [
+        (XY, XYZU, fixture1, (2, 3)),  # Add Z and U dimensions
+        (XZ, XYZU, fixture1, (1, 3)),  # Add Y and U dimensions
+        (XU, XYZU, fixture1, (1, 2)),  # Add Y and Z dimensions
+        (YZ, XYZU, fixture1, (0, 3)),  # Add X and U dimensions
+        (YU, XYZU, fixture1, (0, 2)),  # Add X and Z dimensions
+        (ZU, XYZU, fixture1, (0, 1)),  # Add X and Y dimensions
+    ]:
+        # Create tensors using frontend
+        space_r2 = abstract.TensorSpace[source]()
+        t = space_r2.placeholder("t")
+        expand = morphisms.ExpandDims(source, dest)
+        result = expand(t)
+
+        # Direct numpy expansion using explicitly specified axes
+        expected = fixture
+        for axis in axes:
+            expected = np.expand_dims(expected, axis)
+
+        # Compare results
+        actual = evaluator.evaluate(
+            result.node, evaluator.StateWithoutCache({"t": fixture})
+        )
+        np.testing.assert_array_equal(actual, expected)

--- a/yakof/frontend/morphisms.py
+++ b/yakof/frontend/morphisms.py
@@ -1,0 +1,281 @@
+"""
+Morphisms Between Tensor Spaces
+===============================
+
+This module implements morphisms between tensor spaces, allowing tensors to be
+transformed between spaces of different dimensions via expansion and projection.
+
+Main Classes
+------------
+
+ExpandDims
+    The primary class for expanding tensors to higher dimensional spaces by
+    inserting new dimensions in the correct positions.
+
+ProjectUsingSum
+    The primary class for projecting tensors to lower dimensional spaces by
+    summing over removed dimensions.
+
+Low-Level Functions
+-------------------
+
+axes_expansion
+    Internal function for calculating positions where new dimensions should
+    be inserted. Most users should use ExpandDims instead.
+
+axes_projection
+    Internal function for calculating which dimensions to sum over. Most users
+    should use ProjectUsingSum instead.
+
+generate_canonical_axes
+    Generates canonical axes IDs for a 1-dimensional tensor space of given size.
+
+Implementation Details
+----------------------
+
+The implementation relies on three key properties:
+
+1. Canonical axes: Each dimension has a unique integer ID (e.g., X=1000,
+   Y=1001, Z=1002). This establishes a consistent ordering and makes
+   debugging easier by clearly distinguishing axes from array indices.
+
+2. Monotonicity: Dimensions are always used in ascending order of their IDs.
+   Both source and destination spaces must maintain this ordering.
+
+3. Subset relationships: For expansion, source axes must be a subset of
+   destination axes. For projection, destination axes must be a subset of
+   source axes.
+
+Examples
+--------
+Expand a 1D tensor in Z space to a 2D tensor in YZ space:
+
+    >>> expand = ExpandDims(Z, YZ)  # Z ⊆ YZ
+    >>> yz_tensor = expand(z_tensor)  # Adds Y dimension at index 0
+
+Project a 3D tensor in XYZ space to a 2D tensor in XZ space:
+
+    >>> project = ProjectUsingSum(XYZ, XZ)  # XZ ⊆ XYZ
+    >>> xz_tensor = project(xyz_tensor)  # Sums over Y dimension
+"""
+
+from typing import Callable, Protocol, runtime_checkable
+
+from . import abstract, graph
+
+
+def generate_canonical_axes(size: int) -> tuple[int, ...]:
+    """Generates axes IDs for the 1-dimensional tensors defining a R^size space.
+
+    This provides a convenient way to get consistent dimension IDs for
+    a space of given size. The IDs will be equally spaced monotonically
+    increasing integers and there is no guarantee that they will be
+    starting from zero. (Actually, using numbers around zero makes it
+    very hard when debugging to set apart indexes and axes IDs.)
+
+    Examples:
+        >>> generate_canonical_axes(3)
+        (1000, 1001, 1002)
+        >>> generate_canonical_axes(2)
+        (1000, 1001)
+    """
+    return tuple(x + 1000 for x in range(size))
+
+
+def axes_expansion(source: graph.Axis, dest: graph.Axis) -> graph.Axis:
+    """Calculate axes for expanding from source to destination space.
+
+    .. warning::
+        This is a low-level function. Most users should use ExpandDims instead.
+
+    Determines which axes to insert when expanding a tensor from the source
+    space to the destination space. Handles single axis and multiple axes.
+
+    Args:
+        source: Dimension(s) in source space
+        dest: Dimension(s) in destination space
+
+    Returns:
+        Single axis position if only one dimension needs to be inserted,
+        otherwise tuple of positions for inserting new dimensions
+
+    Raises:
+        ValueError: if source is not a subset of dest.
+        ValueError: if source values are not monotonically increasing.
+        ValueError: if dest values are not monotonically increasing.
+
+    Examples:
+        >>> x, y, z = generate_canonical_axes(3)  # Get distinct axis IDs
+        >>> axes_expansion((x,), (x, y))
+        1  # Position to insert Y
+        >>> axes_expansion((x,), (x, y, z))
+        (1, 2)  # Positions to insert Y and Z
+
+    See Also:
+        ExpandDims: The high-level API for dimension expansion
+    """
+    # Handle single axis case
+    source = source if isinstance(source, tuple) else (source,)
+    dest = dest if isinstance(dest, tuple) else (dest,)
+
+    # Ensure that the destination is a subset of the source
+    if not set(source).issubset(set(dest)):
+        raise ValueError("source must be a subset of destination")
+
+    # Ensure that source has monotonic values
+    if source != tuple(sorted(source)):
+        raise ValueError("source must have monotonic values")
+
+    # Ensure that dest has monotonic values
+    if dest != tuple(sorted(dest)):
+        raise ValueError("dest must have monotonic values")
+
+    # Obtain the indexes of the dest values not belonging to source
+    rv = [idx for idx, value in enumerate(dest) if value not in set(source)]
+
+    # Return single axis or tuple based on result size
+    return rv[0] if len(rv) == 1 else tuple(rv)
+
+
+def axes_projection(source: graph.Axis, dest: graph.Axis) -> graph.Axis:
+    """Calculate axes for projecting from source to destination space.
+
+    .. warning::
+        This is a low-level function. Most users should use ProjectUsingSum instead.
+
+    Determines which axes to sum over when projecting a tensor from
+    the source space to the destination space. Handles both single
+    axis and multiple axes cases.
+
+    Args:
+        source: Dimension(s) in source space
+        dest: Dimension(s) in destination space
+
+    Returns:
+        Single axis to sum over if only one dimension needs to be removed,
+        otherwise tuple of axes to sum over
+
+    Raises:
+        ValueError: if dest is not a subset of source.
+        ValueError: if source values are not monotonically increasing.
+        ValueError: if dest values are not monotonically increasing.
+
+    Examples:
+        >>> x, y, z = generate_canonical_axes(3)  # Get distinct axis IDs
+        >>> axes_projection((x, y, z), (x, z))
+        1  # Position of Y to sum over
+        >>> axes_projection((x, y, z), x)
+        (1, 2)  # Positions of Y and Z to sum over
+        >>> axes_projection((x, y, z), (y, z))
+        0  # Position of X to sum over
+
+    See Also:
+        ProjectUsingSum: The high-level API for dimension reduction
+    """
+    # Handle single axis case
+    source = source if isinstance(source, tuple) else (source,)
+    dest = dest if isinstance(dest, tuple) else (dest,)
+
+    # Ensure that the source is a subset of the destination
+    if not set(dest).issubset(set(source)):
+        raise ValueError("destination must be a subset of source")
+
+    # Ensure that source has monotonic values
+    if source != tuple(sorted(source)):
+        raise ValueError("source must have monotonic values")
+
+    # Ensure that dest has monotonic values
+    if dest != tuple(sorted(dest)):
+        raise ValueError("dest must have monotonic values")
+
+    # Obtain the indexes of the source values not belonging to dest
+    rv = [idx for idx, value in enumerate(source) if value not in set(dest)]
+
+    # Return single axis or tuple based on result size
+    return rv[0] if len(rv) == 1 else tuple(rv)
+
+
+@runtime_checkable
+class Basis(Protocol):
+    """Protocol defining the interface for tensor space bases.
+
+    All bases must provide their axes as an ordered tuple of integers, establishing
+    their position in the canonical ordering. To generate the canonical
+    ordering, use the generate_canonical_axes function.
+
+    Examples:
+        >>> class XYBasis:
+        ...     axes = (1000, 1001)  # X and Y axes
+        >>> isinstance(XYBasis(), Basis)
+        True
+    """
+
+    axes: tuple[int, ...]
+
+
+class ExpandDims[A: Basis, B: Basis]:
+    """Morphism that expands tensors to higher dimensional spaces.
+
+    Type Parameters:
+        A: Source basis type
+        B: Destination basis type
+
+    Args:
+        source: Instance of A
+        dest: Instance of B
+
+    Example:
+        >>> expand = ExpandDims(Z, YZ)
+        >>> yz_tensor = expand(z_tensor)  # Expands 1D z_tensor to 2D
+        >>>
+        >>> # Another example with different dimensions:
+        >>> expand2 = ExpandDims(X, XYZ)
+        >>> xyz_tensor = expand2(x_tensor)  # Expands 1D to 3D
+    """
+
+    def __init__(self, source: type[A], dest: type[B]):
+        self.source = source
+        self.dest = dest
+
+    def __call__(self, t: abstract.Tensor[A]) -> abstract.Tensor[B]:
+        """Apply the expansion morphism to a tensor.
+
+        Calculates required axes and uses numpy's expand_dims to insert
+        new dimensions in the correct positions.
+        """
+        axes = axes_expansion(self.source.axes, self.dest.axes)
+        return abstract.Tensor[B](graph.expand_dims(t.node, axis=axes))
+
+
+class ProjectUsingSum[A: Basis, B: Basis]:
+    """Morphism that projects tensors to lower dimensional spaces using summation.
+
+    Type Parameters:
+        A: Source basis type
+        B: Destination basis type
+
+    Args:
+        source: Instance of A
+        dest: Instance of B
+
+    Example:
+        >>> project = ProjectUsingSum(XYZ, XZ)
+        >>> xz_tensor = project(xyz_tensor)  # Projects 3D to 2D
+        >>>
+        >>> # Another example reducing to 1D:
+        >>> project2 = ProjectUsingSum(XYZ, X)
+        >>> x_tensor = project2(xyz_tensor)  # Projects 3D to 1D
+    """
+
+    def __init__(self, source: type[A], dest: type[B]):
+        self.source = source
+        self.dest = dest
+
+    def __call__(self, t: abstract.Tensor[A]) -> abstract.Tensor[B]:
+        """Apply the projection morphism to a tensor.
+
+        Calculates required axes and uses numpy's reduce_sum to eliminate
+        dimensions by summing over them.
+        """
+        axes = axes_projection(self.source.axes, self.dest.axes)
+        return abstract.Tensor[B](graph.reduce_sum(t.node, axis=axes))


### PR DESCRIPTION
A morphism is a transformation between different tensor spaces. They transform a tensor in a given space into a tensor in another space.

Adding support for this functionality complements our existing set of endomorphisms operations, i.e., operations that transform a tensor a given type into a tensor of the same type.

Equipped with this functionality, we can now define bases and spaces for domain-specific problems.

The core of this diff consists of the following concepts:

1. defining a uniform way to assign unique numbers to axes, which is done inside `morphisms.generate_canonical_axes`;

2. figuring out a way to embed axes into distinct types, which is implemented by `morphisms.Basis`;

3. defining classes for instantiating morphisms, currently `morphisms.ExpandDims` and `morphisms.ProjectUsingSum`, which map to the two common operations `np.expand_dims(axis=...)` and `np.sum(..., axis=...)`;

4. mapping the numbers assigned to axis to relative axes positions expected by numpy, which depend on the geometry of the problem, which we implement with:

- `axes_expansion`

- `axes_projection`

The test suite adds exhaustive testing that those two functions are working as intended in R^4, which should be good enough to spot several corned cases, along with tests ensuring results computed using the frontend and the evaluator match direct numpy computation.