### PR TITLE
fix(pyproject.toml): pin to Python 3.11.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Set up Python
-        run: uv python install
-
       - name: Install dependencies
         run: uv sync --dev
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yakof"
 version = "0.1.0"
 description = "A technology demonstrator for sustainability modeling"
-requires-python = ">=3.12"
+requires-python = "==3.11.11"
 dependencies = [
     "dask[distributed]",
     "matplotlib",


### PR DESCRIPTION
Our intention here is to use the same Python version as the one used on @kazhamiakin et al.'s platform.