### PR TITLE
fix(TensorSpace.placeholder): require name to be present

### DIFF
--- a/yakof/frontend/abstract.py
+++ b/yakof/frontend/abstract.py
@@ -262,25 +262,10 @@ class TensorSpace(Generic[B]):
 
     def placeholder(
         self,
-        name: str = "",
+        name: str,
         default_value: graph.Scalar | None = None,
     ) -> Tensor[B]:
-        """Creates a placeholder tensor.
-
-        The name parameter is optional to allow using autonaming.context():
-
-            >>> with autonaming.context():
-            ...     x = space.placeholder()  # automatically named 'x'
-
-        But must be explicitly provided otherwise:
-
-            >>> y = space.placeholder("y")  # explicitly named
-
-        Failing to name a tensor would cause the grap evaluation to fail. We highly
-        recommend using autonaming to provide a name to tensors.
-        """
-        # TODO(bassosimone): perhaps autonaming should be a higher-level feature? We should
-        # decide whether do to this *before* merging this code into the dt-model repo.
+        """Creates a placeholder tensor."""
         return self.new_tensor(graph.placeholder(name, default_value))
 
     def constant(self, value: graph.Scalar, name: str = "") -> Tensor[B]:


### PR DESCRIPTION
This constructor is still relatively low level. Allowing the name to be omitted would probably make the code more confusing, while being of little convenience, since there is little expectation that one would write this code directly and manually. By doing this, we resolve a TODO left in the codebase ahead of attempting to merge this code into the dt_model.