### PR TITLE
feat(graph): auto-assign unique ID to nodes

### DIFF
--- a/tests/atomic/test_int.py
+++ b/tests/atomic/test_int.py
@@ -1,0 +1,47 @@
+"""Tests for the yakof.atomic.Int type."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+import pytest
+from yakof.atomic import Int
+
+
+def test_atomic_int_basic():
+    """Test basic operations of atomic Int."""
+    counter = Int()
+    assert counter.load() == 0  # Initial value
+
+    # Test add operation
+    assert counter.add(1) == 1  # Returns new value
+    assert counter.load() == 1  # Verify current value
+
+    # Test larger increments
+    assert counter.add(10) == 11
+    assert counter.load() == 11
+
+
+def test_atomic_int_thread_safety():
+    """Test thread safety of atomic Int."""
+    counter = Int()
+    iterations = 1000
+    threads = 10
+
+    def increment_counter():
+        for _ in range(iterations):
+            counter.add(1)
+
+    # Create and start threads
+    thread_list = []
+    for _ in range(threads):
+        thread = threading.Thread(target=increment_counter)
+        thread_list.append(thread)
+        thread.start()
+
+    # Wait for all threads to complete
+    for thread in thread_list:
+        thread.join()
+
+    # Check final counter value
+    # If counter is thread-safe, value should be threads * iterations
+    assert counter.load() == threads * iterations

--- a/tests/frontend/test_abstract.py
+++ b/tests/frontend/test_abstract.py
@@ -509,3 +509,65 @@ def test_tensor_space_axes_method():
     none_space = abstract.TensorSpace(None)
     with pytest.raises(TypeError, match="must be an instance of Basis"):
         none_space.axes()
+
+
+def test_tensor_id_property():
+    """Test that Tensor exposes its node's ID property."""
+    space = abstract.TensorSpace(DummyBasis())
+
+    # Create tensors
+    x = space.placeholder("x")
+    y = space.placeholder("y")
+
+    # Test ID access
+    assert hasattr(x, "id")
+    assert isinstance(x.id, int)
+
+    # Test uniqueness
+    assert x.id != y.id
+
+    # Test ID propagation through operations
+    z = x + y
+    assert z.id == z.node.id
+    assert z.id != x.id
+    assert z.id != y.id
+
+
+def test_tensor_id_consistency():
+    """Test that tensor ID is consistent with its node ID."""
+    space = abstract.TensorSpace(DummyBasis())
+    x = space.placeholder("x")
+
+    # Verify the tensor's ID matches its node's ID
+    assert x.id == x.node.id
+
+    # Create operation and verify ID consistency
+    y = space.exp(x)
+    assert y.id == y.node.id
+
+
+def test_id_through_tensor_operations():
+    """Test ID behavior through various tensor operations."""
+    space = abstract.TensorSpace(DummyBasis())
+    a = space.placeholder("a")
+    b = space.placeholder("b")
+
+    # Test various operations
+    operations = [
+        a + b,
+        a - b,
+        a * b,
+        a / b,
+        a < b,
+        a & b,
+        space.exp(a),
+        space.maximum(a, b),
+    ]
+
+    # Verify all operations have unique IDs
+    ids = [op.id for op in operations]
+    assert len(set(ids)) == len(ids)
+
+    # Verify underlying node IDs match
+    for op in operations:
+        assert op.id == op.node.id

--- a/tests/frontend/test_graph.py
+++ b/tests/frontend/test_graph.py
@@ -167,3 +167,50 @@ def test_where_operation():
     assert result.condition is condition
     assert result.then is then
     assert result.otherwise is otherwise
+
+
+def test_node_id_generation():
+    """Test that nodes receive unique, incrementing IDs."""
+    # Create multiple nodes of different types
+    nodes = [
+        graph.Node(),
+        graph.constant(1.0),
+        graph.placeholder("x"),
+        graph.Node(),
+    ]
+
+    # Check that IDs exist and are unique
+    ids = [node.id for node in nodes]
+    assert len(set(ids)) == len(ids)  # All IDs should be unique
+
+    # Verify IDs are increasing
+    for i in range(1, len(ids)):
+        assert ids[i] > ids[i - 1]
+
+
+def test_node_id_persistence():
+    """Test that node IDs remain stable across operations."""
+    a = graph.placeholder("a")
+    id_a = a.id
+
+    # Perform operations that use the node
+    traced_a = graph.tracepoint(a)
+
+    # Verify node identity is preserved and ID remains the same
+    assert traced_a is a
+    assert traced_a.id == id_a
+
+
+def test_binary_op_node_ids():
+    """Test that binary operation nodes get unique IDs."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+
+    op1 = graph.add(a, b)
+    op2 = graph.subtract(a, b)
+
+    assert hasattr(op1, "id")
+    assert hasattr(op2, "id")
+    assert op1.id != op2.id
+    assert op1.id != a.id
+    assert op1.id != b.id

--- a/yakof/atomic/__init__.py
+++ b/yakof/atomic/__init__.py
@@ -1,0 +1,50 @@
+"""
+Atomic Operations
+=================
+
+This module provides thread-safe atomic operations for integer values.
+It implements an atomic integer counter class similar to Go's atomic.Int64.
+"""
+
+import threading
+
+
+class Int:
+    """
+    A thread-safe integer class supporting atomic operations.
+
+    This class provides atomic operations on integer values by using
+    a lock to ensure thread-safety. It allows incrementing, adding,
+    and reading values without race conditions in multithreaded environments.
+    """
+
+    def __init__(self):
+        """
+        Initialize an atomic integer with a value of 0.
+        """
+        self.__value = 0
+        self.__lock = threading.Lock()
+
+    def add(self, value: int) -> int:
+        """
+        Atomically add a value to the current value.
+
+        Args:
+            value (int): The value to add.
+
+        Returns:
+            int: The new value after addition.
+        """
+        with self.__lock:
+            self.__value += value
+            return self.__value
+
+    def load(self) -> int:
+        """
+        Atomically load and return the current value.
+
+        Returns:
+            int: The current value.
+        """
+        with self.__lock:
+            return self.__value

--- a/yakof/frontend/abstract.py
+++ b/yakof/frontend/abstract.py
@@ -142,6 +142,11 @@ class Tensor(Generic[B]):
         self.space = space
         self.node = node
 
+    # Allows accessing the underlying node ID transparently
+    @property
+    def id(self) -> int:
+        return self.node.id
+
     # autonaming.Namer protocol implementation
     def implements_namer(self) -> None:
         """This method is part of the autonaming.Namer protocol"""

--- a/yakof/frontend/graph.py
+++ b/yakof/frontend/graph.py
@@ -67,6 +67,8 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from .. import atomic
+
 
 Axis = int | tuple[int, ...]
 """Type alias for axis specifications in shape operations."""
@@ -80,6 +82,10 @@ NODE_FLAG_TRACE = 1 << 0
 
 NODE_FLAG_BREAK = 1 << 1
 """Inserts a breakpoint at the corresponding graph node."""
+
+
+_id_generator = atomic.Int()
+"""Atomic integer generator for unique node IDs."""
 
 
 class Node:
@@ -103,6 +109,7 @@ class Node:
     def __init__(self, name: str = "") -> None:
         self.name = name
         self.flags = 0
+        self.id = _id_generator.add(1)
 
     def __hash__(self) -> int:
         # Note: introducing hashing by identity in the class inheritance


### PR DESCRIPTION
This diff introduces atomic integers and uses them to assign unique IDs to graph nodes. We do this for several reasons including (1) assigning a unique ID to help with the dashboards and (2) reordering nodes by creation time. Specifically, soon I will commit a diff that takes advantage of the latter.