### PR TITLE
refactor(numpybackend): create module for dispatch tables

### DIFF
--- a/yakof/numpybackend/dispatch.py
+++ b/yakof/numpybackend/dispatch.py
@@ -1,0 +1,114 @@
+"""
+Dispatch Operations
+===================
+
+This module contains the dispatch tables mapping frontend graph
+operations to the corresponding numpy operations.
+
+These tables are used by the evaluator to map symbolic operations in the graph
+to their concrete NumPy implementations. To extend the system with new operations,
+simply add entries to the appropriate dispatch table.
+"""
+
+from typing import Callable, TypeAlias
+
+import numpy as np
+
+from ..frontend import graph
+
+# Type aliases for operation function signatures
+BinaryOpFunc: TypeAlias = Callable[[np.ndarray, np.ndarray], np.ndarray]
+UnaryOpFunc: TypeAlias = Callable[[np.ndarray], np.ndarray]
+AxisOpFunc: TypeAlias = Callable[[np.ndarray, graph.Axis], np.ndarray]
+
+binary_operations: dict[type[graph.BinaryOp], BinaryOpFunc] = {
+    graph.add: np.add,
+    graph.subtract: np.subtract,
+    graph.multiply: np.multiply,
+    graph.divide: np.divide,
+    graph.equal: np.equal,
+    graph.not_equal: np.not_equal,
+    graph.less: np.less,
+    graph.less_equal: np.less_equal,
+    graph.greater: np.greater,
+    graph.greater_equal: np.greater_equal,
+    graph.logical_and: np.logical_and,
+    graph.logical_or: np.logical_or,
+    graph.logical_xor: np.logical_xor,
+    graph.power: np.power,
+    graph.maximum: np.maximum,
+}
+"""Maps a binary op in the graph domain to the corresponding numpy operation.
+
+These operations take two arrays as input and produce a single array output,
+following NumPy's broadcasting rules for shape compatibility.
+
+Add entries to this table to support more binary operations.
+"""
+
+
+unary_operations: dict[type[graph.UnaryOp], UnaryOpFunc] = {
+    graph.logical_not: np.logical_not,
+    graph.exp: np.exp,
+    graph.log: np.log,
+}
+"""Maps a unary op in the graph domain to the corresponding numpy operation.
+
+These operations take a single array as input and apply the function
+element-wise, producing an output of the same shape.
+
+Add entries to this table to support more unary operations.
+"""
+
+
+def __expand_dims(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
+    """Expand input array with a new axis at the specified position.
+
+    Args:
+        x: The input array to expand
+        axis: The position where the new axis is placed
+
+    Returns:
+        Array with the expanded dimension
+    """
+    return np.expand_dims(x, axis)
+
+
+def __reduce_sum(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
+    """Reduce an array by summing along the specified axis.
+
+    Args:
+        x: The input array to reduce
+        axis: The axis along which to perform the sum
+
+    Returns:
+        Array with the specified axis reduced by summation
+    """
+    return np.sum(x, axis=axis)
+
+
+def __reduce_mean(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
+    """Reduce an array by computing the mean along the specified axis.
+
+    Args:
+        x: The input array to reduce
+        axis: The axis along which to compute the mean
+
+    Returns:
+        Array with the specified axis reduced by averaging
+    """
+    return np.mean(x, axis=axis)
+
+
+axes_operations: dict[type[graph.AxisOp], AxisOpFunc] = {
+    graph.expand_dims: __expand_dims,
+    graph.reduce_sum: __reduce_sum,
+    graph.reduce_mean: __reduce_mean,
+}
+"""Maps an axis op in the graph domain to the corresponding numpy operation.
+
+These operations take an array and an axis parameter, performing
+transformations that affect the array's dimensionality or reduce values
+along the specified axis.
+
+Add entries to this table to support more axis operations."""

--- a/yakof/numpybackend/evaluator.py
+++ b/yakof/numpybackend/evaluator.py
@@ -55,6 +55,7 @@ from typing import Protocol, runtime_checkable
 import numpy as np
 
 from ..frontend import graph, pretty
+from . import dispatch
 
 
 @runtime_checkable
@@ -168,59 +169,6 @@ def _print_result(node: graph.Node, value: np.ndarray, cached: bool = False) -> 
     print("")
 
 
-# This dispatch table maps a binary op in the graph domain
-# to the corresponding numpy operation. Add to this table to
-# add support for more binary operations.
-binary_ops_dispatch_table = {
-    graph.add: np.add,
-    graph.subtract: np.subtract,
-    graph.multiply: np.multiply,
-    graph.divide: np.divide,
-    graph.equal: np.equal,
-    graph.not_equal: np.not_equal,
-    graph.less: np.less,
-    graph.less_equal: np.less_equal,
-    graph.greater: np.greater,
-    graph.greater_equal: np.greater_equal,
-    graph.logical_and: np.logical_and,
-    graph.logical_or: np.logical_or,
-    graph.logical_xor: np.logical_xor,
-    graph.power: np.power,
-    graph.maximum: np.maximum,
-}
-
-
-# Like binary_ops_dispatch_table but for unary operations
-unary_ops_dispatch_table = {
-    graph.logical_not: np.logical_not,
-    graph.exp: np.exp,
-    graph.log: np.log,
-}
-
-
-def __expand_dims(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
-    """Internal expand_dims implementation used by axis_ops_dispatch_table"""
-    return np.expand_dims(x, axis)
-
-
-def __reduce_sum(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
-    """Internal reduce_sum implementation used by axis_ops_dispatch_table"""
-    return np.sum(x, axis=axis)
-
-
-def __reduce_mean(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
-    """Internal reduce_mean implementation used by axis_ops_dispatch_table"""
-    return np.mean(x, axis=axis)
-
-
-# Like binary_ops_dispatch_table but for axis operations
-axis_ops_dispatch_table = {
-    graph.expand_dims: __expand_dims,
-    graph.reduce_sum: __reduce_sum,
-    graph.reduce_mean: __reduce_mean,
-}
-
-
 def evaluate(node: graph.Node, state: State) -> np.ndarray:
     """Evaluates a computation graph node to a NumPy array.
 
@@ -302,7 +250,7 @@ def _evaluate(node: graph.Node, state: State) -> np.ndarray:
         left = evaluate(node.left, state)
         right = evaluate(node.right, state)
         try:
-            return binary_ops_dispatch_table[type(node)](left, right)
+            return dispatch.binary_operations[type(node)](left, right)
         except KeyError:
             raise TypeError(f"evaluator: unknown binary operation: {type(node)}")
 
@@ -310,7 +258,7 @@ def _evaluate(node: graph.Node, state: State) -> np.ndarray:
     if isinstance(node, graph.UnaryOp):
         operand = evaluate(node.node, state)
         try:
-            return unary_ops_dispatch_table[type(node)](operand)
+            return dispatch.unary_operations[type(node)](operand)
         except KeyError:
             raise TypeError(f"evaluator: unknown unary operation: {type(node)}")
 
@@ -335,7 +283,7 @@ def _evaluate(node: graph.Node, state: State) -> np.ndarray:
     if isinstance(node, graph.AxisOp):
         operand = evaluate(node.node, state)
         try:
-            return axis_ops_dispatch_table[type(node)](operand, node.axis)
+            return dispatch.axes_operations[type(node)](operand, node.axis)
         except KeyError:
             raise TypeError(f"evaluator: unknown axis operation: {type(node)}")
 


### PR DESCRIPTION
Rather than keeping the dispatch tables inside evaluator.py, move them into a separate module, which allows sharing them, in the future, with other implementations of the evaluator concept.

This commit serves as a hint that I am adding support for more evaluators in the near future, since I think we need to experiment a bit with evaluating the linearized graph.