### PR TITLE
feat(numpybackend): introduce topological executor

### DIFF
--- a/tests/numpybackend/test_executor.py
+++ b/tests/numpybackend/test_executor.py
@@ -1,0 +1,668 @@
+"""Tests for the yakof.numpybackend.executor module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from yakof.frontend import graph, linearize
+from yakof.numpybackend import evaluator, executor
+
+
+def test_constant_evaluation():
+    """Test evaluation of constant nodes with the executor."""
+    # Create and linearize constant nodes
+    node1 = graph.constant(1.0)
+    node2 = graph.constant(True)
+    node3 = graph.constant(42)
+
+    # Create execution plans
+    plan1 = linearize.forest(node1)
+    plan2 = linearize.forest(node2)
+    plan3 = linearize.forest(node3)
+
+    # Create state for executor
+    state1 = executor.State({})
+    state2 = executor.State({})
+    state3 = executor.State({})
+
+    # Execute each node in the plan
+    for node in plan1:
+        executor.evaluate(state1, node)
+    for node in plan2:
+        executor.evaluate(state2, node)
+    for node in plan3:
+        executor.evaluate(state3, node)
+
+    # Check results
+    assert np.array_equal(state1.values[node1], np.array(1.0))
+    assert np.array_equal(state2.values[node2], np.array(True))
+    assert np.array_equal(state3.values[node3], np.array(42))
+
+
+def test_placeholder_evaluation():
+    """Test evaluation of placeholder nodes with the executor."""
+    # Create placeholder nodes
+    x = graph.placeholder("x")
+    y = graph.placeholder("y", default_value=3.14)
+
+    # Create execution plans
+    plan_x = linearize.forest(x)
+    plan_y = linearize.forest(y)
+
+    # Test with binding
+    x_value = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    state_x = executor.State({x: x_value})
+    for node in plan_x:
+        executor.evaluate(state_x, node)
+    assert np.array_equal(state_x.values[x], x_value)
+
+    # Test default value
+    state_y = executor.State({})
+    for node in plan_y:
+        executor.evaluate(state_y, node)
+    assert np.array_equal(state_y.values[y], np.array(3.14))
+
+    # Test missing binding
+    state_missing = executor.State({})
+    with pytest.raises(executor.PlaceholderValueNotProvided):
+        for node in plan_x:
+            executor.evaluate(state_missing, node)
+
+
+def test_arithmetic_operations():
+    """Test evaluation of arithmetic operations with the executor."""
+    # Create placeholder nodes
+    x_node = graph.placeholder("x")
+    y_node = graph.placeholder("y")
+
+    # Create operation nodes
+    add_node = graph.add(x_node, y_node)
+    sub_node = graph.subtract(x_node, y_node)
+    mul_node = graph.multiply(x_node, y_node)
+    div_node = graph.divide(x_node, y_node)
+
+    # Create execution plans
+    add_plan = linearize.forest(add_node)
+    sub_plan = linearize.forest(sub_node)
+    mul_plan = linearize.forest(mul_node)
+    div_plan = linearize.forest(div_node)
+
+    # Prepare test data
+    x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+    y = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]])
+
+    # Test addition
+    add_state = executor.State({x_node: x, y_node: y})
+    for node in add_plan:
+        executor.evaluate(add_state, node)
+    assert np.array_equal(add_state.values[add_node], x + y)
+
+    # Test subtraction
+    sub_state = executor.State({x_node: x, y_node: y})
+    for node in sub_plan:
+        executor.evaluate(sub_state, node)
+    assert np.array_equal(sub_state.values[sub_node], x - y)
+
+    # Test multiplication
+    mul_state = executor.State({x_node: x, y_node: y})
+    for node in mul_plan:
+        executor.evaluate(mul_state, node)
+    assert np.array_equal(mul_state.values[mul_node], x * y)
+
+    # Test division
+    div_state = executor.State({x_node: x, y_node: y})
+    for node in div_plan:
+        executor.evaluate(div_state, node)
+    assert np.array_equal(div_state.values[div_node], x / y)
+
+
+def test_comparison_with_evaluator():
+    """Test that executor produces the same results as the evaluator."""
+    # Create a complex graph
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+    z = graph.add(x, y)
+    w = graph.multiply(z, graph.constant(2.0))
+    result = graph.power(w, graph.constant(0.5))  # sqrt of 2 * (x + y)
+
+    # Create execution plan
+    plan = linearize.forest(result)
+
+    # Test data
+    x_val = np.array([[1.0, 2.0], [3.0, 4.0]])
+    y_val = np.array([[5.0, 6.0], [7.0, 8.0]])
+
+    # Evaluate with evaluator
+    eval_state = evaluator.StateWithoutCache({"x": x_val, "y": y_val})
+    eval_result = evaluator.evaluate(result, eval_state)
+
+    # Evaluate with executor
+    exec_state = executor.State({x: x_val, y: y_val})
+    for node in plan:
+        executor.evaluate(exec_state, node)
+    exec_result = exec_state.values[result]
+
+    # Compare results
+    assert np.allclose(eval_result, exec_result)
+
+
+def test_where_operation():
+    """Test where operation with the executor."""
+    # Create nodes
+    cond_node = graph.placeholder("cond")
+    x_node = graph.placeholder("x")
+    y_node = graph.placeholder("y")
+    where_node = graph.where(cond_node, x_node, y_node)
+
+    # Create execution plan
+    plan = linearize.forest(where_node)
+
+    # Test case
+    cond = np.array([[True, False, True], [False, True, False], [True, False, True]])
+    x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+    y = np.array([[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]])
+    expected = np.where(cond, x, y)
+
+    # Evaluate with executor
+    state = executor.State({cond_node: cond, x_node: x, y_node: y})
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Check result
+    assert np.array_equal(state.values[where_node], expected)
+
+
+def test_multi_clause_where():
+    """Test multi-clause where operations with the executor."""
+    # Create nodes
+    cond1 = graph.placeholder("cond1")
+    cond2 = graph.placeholder("cond2")
+    val1 = graph.constant(1.0)
+    val2 = graph.constant(2.0)
+    default = graph.constant(0.0)
+
+    node = graph.multi_clause_where([(cond1, val1), (cond2, val2)], default)
+
+    # Create execution plan
+    plan = linearize.forest(node)
+
+    # Test data
+    cond1_val = np.array(
+        [[True, False, False], [False, True, False], [False, False, True]]
+    )
+    cond2_val = np.array(
+        [[False, True, False], [True, False, False], [False, True, False]]
+    )
+    expected = np.select([cond1_val, cond2_val], [1.0, 2.0], default=0.0)
+
+    # Evaluate with executor
+    state = executor.State({cond1: cond1_val, cond2: cond2_val})
+    for node_in_plan in plan:
+        executor.evaluate(state, node_in_plan)
+
+    # Check result
+    assert np.array_equal(state.values[node], expected)
+
+
+def test_complex_graph():
+    """Test execution of a complex graph with multiple operations."""
+    # Build a more complex graph
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+
+    # x^2 + 2*y
+    x_squared = graph.power(x, graph.constant(2.0))
+    two_y = graph.multiply(y, graph.constant(2.0))
+    sum_term = graph.add(x_squared, two_y)
+
+    # where(x > y, x^2 + 2*y, y - x)
+    diff = graph.subtract(y, x)
+    condition = graph.greater(x, y)
+    result = graph.where(condition, sum_term, diff)
+
+    # Create execution plan
+    plan = linearize.forest(result)
+
+    # Test data
+    x_val = np.array([[1.0, 5.0], [3.0, 2.0]])
+    y_val = np.array([[2.0, 3.0], [1.0, 4.0]])
+
+    # Expected result calculations
+    expected_x_squared = x_val**2
+    expected_two_y = 2 * y_val
+    expected_sum = expected_x_squared + expected_two_y
+    expected_diff = y_val - x_val
+    expected_condition = x_val > y_val
+    expected_result = np.where(expected_condition, expected_sum, expected_diff)
+
+    # Evaluate with executor
+    state = executor.State({x: x_val, y: y_val})
+    for node_in_plan in plan:
+        executor.evaluate(state, node_in_plan)
+
+    # Check intermediate and final results
+    assert np.array_equal(state.values[x_squared], expected_x_squared)
+    assert np.array_equal(state.values[two_y], expected_two_y)
+    assert np.array_equal(state.values[sum_term], expected_sum)
+    assert np.array_equal(state.values[diff], expected_diff)
+    assert np.array_equal(state.values[condition], expected_condition)
+    assert np.array_equal(state.values[result], expected_result)
+
+
+def test_debug_flags(capsys, monkeypatch):
+    """Test debug flags for tracing and breaking."""
+    # Mock input function
+    mock_input_calls = []
+
+    def mock_input(prompt):
+        mock_input_calls.append(prompt)
+        return ""
+
+    monkeypatch.setattr("builtins.input", mock_input)
+
+    # Create a simple graph
+    x = graph.placeholder("x")
+    y = graph.multiply(x, graph.constant(2.0))
+
+    # Set trace flag on node
+    traced_y = graph.tracepoint(y)
+
+    # Create execution plan
+    plan = linearize.forest(traced_y)
+
+    # Evaluate with trace flag
+    state = executor.State({x: np.array([1.0, 2.0, 3.0])})
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Check trace output
+    captured = capsys.readouterr()
+    assert "=== begin tracepoint ===" in captured.out
+
+    # Test global trace flag
+    z = graph.add(x, graph.constant(5.0))
+    plan = linearize.forest(z)
+
+    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=executor.FLAG_TRACE)
+    for node in plan:
+        executor.evaluate(state, node)
+
+    captured = capsys.readouterr()
+    assert "=== begin tracepoint ===" in captured.out
+
+    # Test break flag on named node
+    named_node = graph.add(x, graph.constant(10.0))
+    named_node.name = "named_addition"
+    plan = linearize.forest(named_node)
+
+    state = executor.State(
+        {x: np.array([1.0, 2.0, 3.0])}, flags=executor.FLAG_BREAK_ON_NAMED_NODE
+    )
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Check that input was called (breakpoint triggered)
+    assert len(mock_input_calls) > 0
+
+
+def test_error_handling():
+    """Test error handling in the executor."""
+    # Create a node with missing dependency
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+    z = graph.add(x, y)
+    plan = linearize.forest(z)
+
+    # Test missing placeholder value
+    state = executor.State({x: np.array([1.0, 2.0])})  # y is missing
+    with pytest.raises(executor.PlaceholderValueNotProvided):
+        for node in plan:
+            executor.evaluate(state, node)
+
+    # Test unknown node type
+    class unknown_node(graph.Node):
+        pass
+
+    with pytest.raises(executor.UnsupportedNodeType):
+        executor.evaluate(executor.State({}), unknown_node())
+
+    # Test unknown operation
+    class unknown_binary(graph.BinaryOp):
+        pass
+
+    unknown_op = unknown_binary(graph.constant(1.0), graph.constant(2.0))
+    plan = linearize.forest(unknown_op)
+    state = executor.State({})
+
+    with pytest.raises(executor.UnsupportedOperation):
+        for node in plan:
+            executor.evaluate(state, node)
+
+    # Test evaluation ordering error (missing dependency)
+    x = graph.placeholder("x")
+    y = graph.add(x, graph.constant(1.0))
+
+    # Not following the plan order - trying to evaluate y before x
+    state = executor.State({x: np.array([1.0])})
+    with pytest.raises(executor.NodeValueNotFound):
+        executor.evaluate(state, y)  # Should fail, x not evaluated yet
+
+
+def test_reduction_operations():
+    """Test reduction operations with the executor."""
+    # Create nodes
+    x = graph.placeholder("x")
+    sum_node = graph.reduce_sum(x, axis=0)
+    mean_node = graph.reduce_mean(x, axis=1)
+
+    # Create execution plans
+    sum_plan = linearize.forest(sum_node)
+    mean_plan = linearize.forest(mean_node)
+
+    # Test data
+    x_val = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+
+    # Test sum reduction
+    sum_state = executor.State({x: x_val})
+    for node in sum_plan:
+        executor.evaluate(sum_state, node)
+    assert np.array_equal(sum_state.values[sum_node], np.sum(x_val, axis=0))
+
+    # Test mean reduction
+    mean_state = executor.State({x: x_val})
+    for node in mean_plan:
+        executor.evaluate(mean_state, node)
+    assert np.array_equal(mean_state.values[mean_node], np.mean(x_val, axis=1))
+
+
+def test_expand_dims_operation():
+    """Test expand_dims operation with the executor."""
+    # Create nodes
+    x = graph.placeholder("x")
+    expanded0 = graph.expand_dims(x, axis=0)
+    expanded1 = graph.expand_dims(x, axis=1)
+    expanded2 = graph.expand_dims(x, axis=2)
+
+    # Create execution plans
+    plan0 = linearize.forest(expanded0)
+    plan1 = linearize.forest(expanded1)
+    plan2 = linearize.forest(expanded2)
+
+    # Test data
+    x_val = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])  # 2x3
+
+    # Test expand dims on axis 0
+    state0 = executor.State({x: x_val})
+    for node in plan0:
+        executor.evaluate(state0, node)
+    result0 = state0.values[expanded0]
+    assert result0.shape == (1, 2, 3)
+    assert np.array_equal(result0[0], x_val)
+
+    # Test expand dims on axis 1
+    state1 = executor.State({x: x_val})
+    for node in plan1:
+        executor.evaluate(state1, node)
+    result1 = state1.values[expanded1]
+    assert result1.shape == (2, 1, 3)
+    assert np.array_equal(result1[:, 0, :], x_val)
+
+    # Test expand dims on axis 2
+    state2 = executor.State({x: x_val})
+    for node in plan2:
+        executor.evaluate(state2, node)
+    result2 = state2.values[expanded2]
+    assert result2.shape == (2, 3, 1)
+    assert np.array_equal(result2[:, :, 0], x_val)
+
+
+def test_execute_plan_helper():
+    """Test a helper function to execute an entire plan in one go."""
+    # This test demonstrates how you might create a helper function
+    # to simplify the common pattern of executing a linearized plan
+
+    def execute_plan(plan, initial_state):
+        """Helper to execute a full plan with the given initial state."""
+        state = initial_state
+        for node in plan:
+            executor.evaluate(state, node)
+        return state
+
+    # Create a simple graph
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+    z = graph.add(x, y)
+    w = graph.multiply(z, graph.constant(2.0))
+
+    # Linearize
+    plan = linearize.forest(w)
+
+    # Execute the plan
+    x_val = np.array([1.0, 2.0, 3.0])
+    y_val = np.array([4.0, 5.0, 6.0])
+
+    state = execute_plan(plan, executor.State({x: x_val, y: y_val}))
+
+    # Check result
+    assert np.array_equal(state.values[w], (x_val + y_val) * 2.0)
+
+
+def test_comparison_operations():
+    """Test comparison operations with the executor."""
+    # Create placeholder nodes
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+
+    # Create comparison nodes
+    lt = graph.less(x, y)
+    gt = graph.greater(x, y)
+    eq = graph.equal(x, y)
+    ne = graph.not_equal(x, y)
+    le = graph.less_equal(x, y)
+    ge = graph.greater_equal(x, y)
+
+    # Create execution plans
+    plans = {op: linearize.forest(op) for op in [lt, gt, eq, ne, le, ge]}
+
+    # Test data
+    x_val = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    y_val = np.array([[2.0, 2.0, 2.0], [5.0, 5.0, 5.0]])
+
+    # Expected results
+    expected = {
+        lt: x_val < y_val,
+        gt: x_val > y_val,
+        eq: x_val == y_val,
+        ne: x_val != y_val,
+        le: x_val <= y_val,
+        ge: x_val >= y_val,
+    }
+
+    # Test each operation
+    for op, plan in plans.items():
+        state = executor.State({x: x_val, y: y_val})
+        for node in plan:
+            executor.evaluate(state, node)
+        assert np.array_equal(state.values[op], expected[op])
+
+
+def test_state_value_access():
+    """Test the State.get method for accessing node values."""
+    # Create a node and a state
+    x = graph.placeholder("x")
+    y = graph.constant(2.0)
+    z = graph.add(x, y)
+
+    state = executor.State({x: np.array([1.0, 2.0, 3.0])})
+
+    # Evaluate constant node
+    executor.evaluate(state, y)
+
+    # Test that node exists in state.values
+    assert y in state.values
+
+
+def test_placeholder_with_state_value():
+    """Test evaluation of placeholders with values provided in the state."""
+    # Create placeholder nodes with and without default values
+    x_no_default = graph.placeholder("x_no_default")
+    squared = graph.power(x_no_default, graph.constant(2.0))
+    y_with_default = graph.placeholder("y_with_default", default_value=100.0)
+
+    # Create plan for both nodes
+    plan = linearize.forest(x_no_default, squared, y_with_default)
+
+    # Test case 1: Both placeholders provided in state
+    state1 = executor.State({
+        x_no_default: np.array([1.0, 2.0, 3.0]),
+        y_with_default: np.array([4.0, 5.0, 6.0])  # Overrides default value
+    })
+
+    for node in plan:
+        executor.evaluate(state1, node)
+
+    assert np.array_equal(state1.values[x_no_default], np.array([1.0, 2.0, 3.0]))
+    assert np.array_equal(state1.values[y_with_default], np.array([4.0, 5.0, 6.0]))
+
+    # Test case 2: Only placeholder without default provided in state
+    # (the other one should use default value)
+    state2 = executor.State({
+        x_no_default: np.array([7.0, 8.0, 9.0]),
+        # y_with_default not provided, should use default
+    })
+
+    for node in plan:
+        executor.evaluate(state2, node)
+
+    assert np.array_equal(state2.values[x_no_default], np.array([7.0, 8.0, 9.0]))
+    assert np.array_equal(state2.values[y_with_default], np.array(100.0))
+
+    # Test case 3: Only placeholder with default provided in state
+    # (the other one should fail)
+    state3 = executor.State({
+        # x_no_default not provided, should fail
+        y_with_default: np.array([10.0, 11.0, 12.0])
+    })
+
+    # This should raise an error when x_no_default is evaluated
+    with pytest.raises(executor.PlaceholderValueNotProvided):
+        for node in plan:
+            executor.evaluate(state3, node)
+
+
+def test_unary_operations():
+    """Test all supported unary operations and an unsupported one."""
+    # Create placeholder node
+    x = graph.placeholder("x")
+
+    # Create various unary operation nodes
+    exp_node = graph.exp(x)
+    log_node = graph.log(x)
+    not_node = graph.logical_not(x)
+
+    # Create execution plans
+    exp_plan = linearize.forest(exp_node)
+    log_plan = linearize.forest(log_node)
+    not_plan = linearize.forest(not_node)
+
+    # Test data
+    x_numeric = np.array([[-1.0, 2.0, -3.0], [4.0, -5.0, 6.0]])
+    x_boolean = np.array([[True, False], [False, True]])
+
+    # Test each operation with appropriate input type
+
+    # Test exponential
+    exp_state = executor.State({x: x_numeric})
+    for node in exp_plan:
+        executor.evaluate(exp_state, node)
+    assert np.array_equal(exp_state.values[exp_node], np.exp(x_numeric))
+
+    # Test logarithm (using positive values to avoid warnings)
+    log_state = executor.State({x: np.abs(x_numeric)})
+    for node in log_plan:
+        executor.evaluate(log_state, node)
+    assert np.array_equal(log_state.values[log_node], np.log(np.abs(x_numeric)))
+
+    # Test logical not
+    not_state = executor.State({x: x_boolean})
+    for node in not_plan:
+        executor.evaluate(not_state, node)
+    assert np.array_equal(not_state.values[not_node], np.logical_not(x_boolean))
+
+    # Test unsupported unary operation
+    class UnsupportedUnaryOp(graph.UnaryOp):
+        pass
+
+    unsupported_node = UnsupportedUnaryOp(x)
+    unsupported_plan = linearize.forest(unsupported_node)
+
+    unsupported_state = executor.State({x: x_numeric})
+
+    with pytest.raises(executor.UnsupportedOperation):
+        for node in unsupported_plan:
+            executor.evaluate(unsupported_state, node)
+
+
+def test_axis_operations():
+    """Test all supported axis operations and an unsupported one."""
+    # Create placeholder node
+    x = graph.placeholder("x")
+
+    # Create various axis operation nodes
+    expand_node = graph.expand_dims(x, axis=1)
+    sum_node = graph.reduce_sum(x, axis=0)
+    mean_node = graph.reduce_mean(x, axis=1)
+
+    # Create execution plans
+    expand_plan = linearize.forest(expand_node)
+    sum_plan = linearize.forest(sum_node)
+    mean_plan = linearize.forest(mean_node)
+
+    # Test data
+    x_val = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])  # 3x3
+
+    # Test expand_dims
+    expand_state = executor.State({x: x_val})
+    for node in expand_plan:
+        executor.evaluate(expand_state, node)
+    expected_expand = np.expand_dims(x_val, axis=1)
+    assert np.array_equal(expand_state.values[expand_node], expected_expand)
+    assert expand_state.values[expand_node].shape == (3, 1, 3)
+
+    # Test reduce_sum
+    sum_state = executor.State({x: x_val})
+    for node in sum_plan:
+        executor.evaluate(sum_state, node)
+    expected_sum = np.sum(x_val, axis=0)
+    assert np.array_equal(sum_state.values[sum_node], expected_sum)
+
+    # Test reduce_mean
+    mean_state = executor.State({x: x_val})
+    for node in mean_plan:
+        executor.evaluate(mean_state, node)
+    expected_mean = np.mean(x_val, axis=1)
+    assert np.array_equal(mean_state.values[mean_node], expected_mean)
+
+    # Test unsupported axis operation
+    class UnsupportedAxisOp(graph.AxisOp):
+        pass
+
+    unsupported_node = UnsupportedAxisOp(x, axis=0)
+    unsupported_plan = linearize.forest(unsupported_node)
+
+    unsupported_state = executor.State({x: x_val})
+
+    with pytest.raises(executor.UnsupportedOperation):
+        for node in unsupported_plan:
+            executor.evaluate(unsupported_state, node)
+
+    # Test invalid axis value
+    with pytest.raises(ValueError):  # NumPy raises ValueError for invalid axes
+        # Create a valid node type but with invalid axis
+        invalid_axis_node = graph.reduce_sum(x, axis=5)  # x is only 2D, so axis=5 is invalid
+        invalid_plan = linearize.forest(invalid_axis_node)
+        invalid_state = executor.State({x: x_val})
+
+        for node in invalid_plan:
+            executor.evaluate(invalid_state, node)

--- a/tests/numpybackend/test_executor.py
+++ b/tests/numpybackend/test_executor.py
@@ -514,10 +514,12 @@ def test_placeholder_with_state_value():
     plan = linearize.forest(x_no_default, squared, y_with_default)
 
     # Test case 1: Both placeholders provided in state
-    state1 = executor.State({
-        x_no_default: np.array([1.0, 2.0, 3.0]),
-        y_with_default: np.array([4.0, 5.0, 6.0])  # Overrides default value
-    })
+    state1 = executor.State(
+        {
+            x_no_default: np.array([1.0, 2.0, 3.0]),
+            y_with_default: np.array([4.0, 5.0, 6.0]),  # Overrides default value
+        }
+    )
 
     for node in plan:
         executor.evaluate(state1, node)
@@ -527,10 +529,12 @@ def test_placeholder_with_state_value():
 
     # Test case 2: Only placeholder without default provided in state
     # (the other one should use default value)
-    state2 = executor.State({
-        x_no_default: np.array([7.0, 8.0, 9.0]),
-        # y_with_default not provided, should use default
-    })
+    state2 = executor.State(
+        {
+            x_no_default: np.array([7.0, 8.0, 9.0]),
+            # y_with_default not provided, should use default
+        }
+    )
 
     for node in plan:
         executor.evaluate(state2, node)
@@ -540,10 +544,12 @@ def test_placeholder_with_state_value():
 
     # Test case 3: Only placeholder with default provided in state
     # (the other one should fail)
-    state3 = executor.State({
-        # x_no_default not provided, should fail
-        y_with_default: np.array([10.0, 11.0, 12.0])
-    })
+    state3 = executor.State(
+        {
+            # x_no_default not provided, should fail
+            y_with_default: np.array([10.0, 11.0, 12.0])
+        }
+    )
 
     # This should raise an error when x_no_default is evaluated
     with pytest.raises(executor.PlaceholderValueNotProvided):
@@ -660,7 +666,9 @@ def test_axis_operations():
     # Test invalid axis value
     with pytest.raises(ValueError):  # NumPy raises ValueError for invalid axes
         # Create a valid node type but with invalid axis
-        invalid_axis_node = graph.reduce_sum(x, axis=5)  # x is only 2D, so axis=5 is invalid
+        invalid_axis_node = graph.reduce_sum(
+            x, axis=5
+        )  # x is only 2D, so axis=5 is invalid
         invalid_plan = linearize.forest(invalid_axis_node)
         invalid_state = executor.State({x: x_val})
 

--- a/yakof/numpybackend/debug.py
+++ b/yakof/numpybackend/debug.py
@@ -1,0 +1,28 @@
+"""
+Debugging Code
+==============
+
+This module contains debugging code.
+"""
+
+import numpy as np
+
+from ..frontend import graph, pretty
+
+
+def print_graph_node(node: graph.Node) -> None:
+    """Print a node within the computation graph."""
+    print("=== begin tracepoint ===")
+    print(f"name: {node.name}")
+    print(f"id: {node.id}")
+    print(f"type: {node.__class__}")
+    print(f"formula: {pretty.format(node)}")
+
+
+def print_evaluated_node(value: np.ndarray, cached: bool = False) -> None:
+    """Print a node after evaluation."""
+    print(f"shape: {value.shape}")
+    print(f"cached: {cached}")
+    print(f"value:\n{value}")
+    print("=== end tracepoint ===")
+    print("")

--- a/yakof/numpybackend/evaluator.py
+++ b/yakof/numpybackend/evaluator.py
@@ -59,7 +59,7 @@ from typing import Protocol, runtime_checkable
 import numpy as np
 
 from ..frontend import graph, pretty
-from . import dispatch
+from . import debug, dispatch
 
 
 @runtime_checkable
@@ -163,16 +163,8 @@ def _print_node_evaluation(
     This function prints comprehensive information about a node after it
     has been evaluated, including its metadata, formula, and computed result.
     """
-    print("=== begin tracepoint ===")
-    print(f"name: {node.name}")
-    print(f"id: {node.id}")
-    print(f"type: {node.__class__}")
-    print(f"formula: {pretty.format(node)}")
-    print(f"shape: {value.shape}")
-    print(f"cached: {cached}")
-    print(f"value:\n{value}")
-    print("=== end tracepoint ===")
-    print("")
+    debug.print_graph_node(node)
+    debug.print_evaluated_node(value, cached)
 
 
 def evaluate(node: graph.Node, state: State) -> np.ndarray:

--- a/yakof/numpybackend/executor.py
+++ b/yakof/numpybackend/executor.py
@@ -1,0 +1,228 @@
+"""
+Graph Executor
+==============
+
+An evaluator for computation graphs that processes nodes in
+topological order. Unlike recursive evaluators, this executor requires
+pre-linearized graphs where nodes are sorted such that all dependencies
+of a node appear before the node itself in the evaluation sequence.
+
+This approach offers several advantages:
+- Clearer debugging: execution follows a predictable linear sequence
+- Better tracing: provides a coherent view of computation flow
+- Explicit error handling: clearly identifies missing dependency errors
+
+The executor expects all placeholder values to be provided in the initial
+state and evaluates each node exactly once, storing results for later reuse.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, cast
+
+import numpy as np
+
+from ..frontend import graph
+from . import debug, dispatch
+
+
+FLAG_BREAK_ON_NAMED_NODE = 1 << 0
+"""Configures the executor to break on nodes with a non-empty name."""
+
+FLAG_TRACE = 1 << 1
+"""Configures the executor to trace the computation."""
+
+
+class NodeValueNotFound(Exception):
+    """Raised when a node value is not found in the state."""
+
+
+class UnsupportedNodeType(Exception):
+    """Raised when the executor encounters an unsupported node type."""
+
+
+class UnsupportedOperation(Exception):
+    """Raised when the executor encounters an unsupported operation."""
+
+
+class PlaceholderValueNotProvided(Exception):
+    """Raised when a required placeholder value is not provided in the state."""
+
+
+@dataclass(frozen=True)
+class State:
+    """
+    The graph executor state.
+
+    Make sure to provide values for placeholder nodes ahead of the evaluation
+    by initializing the `values` dictionary accordingly.
+
+    Attributes:
+        values: A dictionary caching the result of the computation.
+        flags: Bitmask containing debug flags (e.g., FLAG_BREAK_ON_NAMED_NODE).
+    """
+
+    values: dict[graph.Node, np.ndarray]
+    flags: int = 0
+
+    def get_node_value(self, node: graph.Node) -> np.ndarray:
+        """Helper function to access the value associated with a node.
+
+        Args:
+            node: The node whose value to retrieve.
+
+        Returns:
+            The value associated with the node.
+
+        Raises:
+            NodeValueNotFound: If the node has not been evaluated.
+        """
+        try:
+            return self.values[node]
+        except KeyError:
+            raise NodeValueNotFound(
+                f"executor: node '{node.name}' has not been evaluated"
+            )
+
+
+def evaluate(state: State, node: graph.Node) -> np.ndarray:
+    """
+    Evaluates a node assuming that all dependent nodes have already
+    been evaluated and cached in the state. In other words, this
+    function assumes you have already linearized the graph. If this
+    is not the case, evaluation will fail. Use the `frontend.linearize`
+    module to ensure the graph is topologically sorted.
+
+    Args:
+        state: The current executor state.
+        node: The node to evaluate.
+
+    Raises:
+        NodeValueNotFound: If a dependent node has not been evaluated
+            and therefore its value cannot be found in the state.
+        UnsupportedNodeType: If the executor does not support the given node type.
+        UnsupportedOperation: If the executor does not support a specific operation.
+        PlaceholderValueNotProvided: If a placeholder node has no value provided
+            and no default value.
+    """
+
+    # 1. check whether node has been already evaluated
+    if node in state.values:
+        return state.values[node]
+
+    # 2. check whether we need to trace this node
+    tracing = node.flags & graph.NODE_FLAG_TRACE != 0 or state.flags & FLAG_TRACE != 0
+    if tracing:
+        debug.print_graph_node(node)
+
+    # 3. evaluate the node proper
+    result = _evaluate(state, node)
+
+    # 4. check whether we need to print the computation result
+    if tracing:
+        debug.print_evaluated_node(result, cached=False)
+
+    # 5. check whether we need to stop after evaluating this node
+    breaking = node.flags & graph.NODE_FLAG_BREAK != 0 or (
+        state.flags & FLAG_BREAK_ON_NAMED_NODE != 0 and node.name
+    )
+    if breaking:
+        input("executor: press any key to continue...")
+        print("")
+
+    # 6. store the node result in the state
+    state.values[node] = result
+
+    # 7. return the result
+    return result
+
+
+def __eval_constant_op(state: State, node: graph.Node) -> np.ndarray:
+    node = cast(graph.constant, node)
+    return np.asarray(node.value)
+
+
+def __eval_placeholder_default(state: State, node: graph.Node) -> np.ndarray:
+    # Note: placeholders are part of the state, so, if we end up
+    # here it means we didn't find anything in the state.
+    node = cast(graph.placeholder, node)
+    if node.default_value is not None:
+        return np.asarray(node.default_value)
+    raise PlaceholderValueNotProvided(
+        f"executor: no value provided for placeholder '{node.name}' and no default value is set"
+    )
+
+
+def __eval_binary_op(state: State, node: graph.Node) -> np.ndarray:
+    node = cast(graph.BinaryOp, node)
+    left = state.get_node_value(node.left)
+    right = state.get_node_value(node.right)
+    try:
+        return dispatch.binary_operations[type(node)](left, right)
+    except KeyError:
+        raise UnsupportedOperation(
+            f"executor: unsupported binary operation: {type(node)}"
+        )
+
+
+def __eval_unary_op(state: State, node: graph.Node) -> np.ndarray:
+    node = cast(graph.UnaryOp, node)
+    operand = state.get_node_value(node.node)
+    try:
+        return dispatch.unary_operations[type(node)](operand)
+    except KeyError:
+        raise UnsupportedOperation(
+            f"executor: unsupported unary operation: {type(node)}"
+        )
+
+
+def __eval_where_op(state: State, node: graph.Node) -> np.ndarray:
+    node = cast(graph.where, node)
+    return np.where(
+        state.get_node_value(node.condition),
+        state.get_node_value(node.then),
+        state.get_node_value(node.otherwise),
+    )
+
+
+def __eval_multi_clause_where_op(state: State, node: graph.Node) -> np.ndarray:
+    node = cast(graph.multi_clause_where, node)
+    conditions = []
+    values = []
+    for cond, value in node.clauses:
+        conditions.append(state.get_node_value(cond))
+        values.append(state.get_node_value(value))
+    default = state.get_node_value(node.default_value)
+    return np.select(conditions, values, default=default)
+
+
+def __eval_axis_op(state: State, node: graph.Node) -> np.ndarray:
+    node = cast(graph.AxisOp, node)
+    operand = state.get_node_value(node.node)
+    try:
+        return dispatch.axes_operations[type(node)](operand, node.axis)
+    except KeyError:
+        raise UnsupportedOperation(
+            f"executor: unsupported axis operation: {type(node)}"
+        )
+
+
+_evaluators: tuple[tuple[type, Callable[[State, graph.Node], np.ndarray]], ...] = (
+    (graph.constant, __eval_constant_op),
+    (graph.placeholder, __eval_placeholder_default),
+    (graph.BinaryOp, __eval_binary_op),
+    (graph.UnaryOp, __eval_unary_op),
+    (graph.where, __eval_where_op),
+    (graph.multi_clause_where, __eval_multi_clause_where_op),
+    (graph.AxisOp, __eval_axis_op),
+)
+
+
+def _evaluate(state: State, node: graph.Node) -> np.ndarray:
+
+    # Attempt to match with every possible evaluator
+    for node_type, evaluator in _evaluators:
+        if isinstance(node, node_type):
+            return evaluator(state, node)
+
+    # Otherwise, just bail
+    raise UnsupportedNodeType(f"executor: unsupported node type: {type(node)}")

--- a/yakof/numpybackend/executor.py
+++ b/yakof/numpybackend/executor.py
@@ -207,7 +207,9 @@ def __eval_axis_op(state: State, node: graph.Node) -> np.ndarray:
         )
 
 
-_evaluators: tuple[tuple[type, Callable[[State, graph.Node], np.ndarray]], ...] = (
+_EvaluatorFunc = Callable[[State, graph.Node], np.ndarray]
+
+_evaluators: tuple[tuple[type[graph.Node], _EvaluatorFunc], ...] = (
     (graph.constant, __eval_constant_op),
     (graph.placeholder, __eval_placeholder_default),
     (graph.BinaryOp, __eval_binary_op),

--- a/yakof/numpybackend/executor.py
+++ b/yakof/numpybackend/executor.py
@@ -105,7 +105,8 @@ def evaluate(state: State, node: graph.Node) -> np.ndarray:
             and no default value.
     """
 
-    # 1. check whether node has been already evaluated
+    # 1. check whether node has been already evaluated (note that this
+    # covers the case of placeholders provided via the state)
     if node in state.values:
         return state.values[node]
 


### PR DESCRIPTION
The executor works as long as we have topologically linearized the graph using the yakof.frontend.linearize package.

If that is the case, the executor will evaluate a node assuming that any dependency has already been evaluted.

As a result, the executor MUST have state, while the tree based evaluator could or could not use state.

Since state is mandatory, we can merge the placeholders and the state, thus further simplifying the code.