### PR TITLE
fix(pretty): stop printing at named formulae

### DIFF
--- a/tests/frontend/test_pretty.py
+++ b/tests/frontend/test_pretty.py
@@ -160,6 +160,96 @@ def test_not_equal_pretty_printing():
     assert result == "x != 2.0"
 
 
+def test_where_pretty_printing():
+    """Test pretty printing of where operation."""
+    cond = graph.placeholder("cond")
+    x = graph.constant(1.0)
+    y = graph.constant(2.0)
+    z = graph.where(cond, x, y)
+
+    result = pretty.format(z)
+    assert result == "where(cond, 1.0, 2.0)"
+
+
+def test_multi_clause_where_pretty_printing():
+    """Test pretty printing of multi_clause_where operation."""
+    cond1 = graph.placeholder("cond1")
+    cond2 = graph.placeholder("cond2")
+    x = graph.constant(1.0)
+    y = graph.constant(2.0)
+    z = graph.constant(3.0)
+
+    expr = graph.multi_clause_where([(cond1, x), (cond2, y)], z)
+    result = pretty.format(expr)
+    assert result == "multi_clause_where([(cond1, 1.0), (cond2, 2.0)], 3.0)"
+
+
+def test_expand_dims_pretty_printing():
+    """Test pretty printing of expand_dims operation."""
+    x = graph.placeholder("x")
+    y = graph.expand_dims(x, 0)
+
+    result = pretty.format(y)
+    assert result == "expand_dims(x, 0)"
+
+    # Test with tuple axis
+    z = graph.expand_dims(x, (0, 1))
+    result = pretty.format(z)
+    assert result == "expand_dims(x, (0, 1))"
+
+
+def test_squeeze_pretty_printing():
+    """Test pretty printing of squeeze operation."""
+    x = graph.placeholder("x")
+    y = graph.squeeze(x, 0)
+
+    result = pretty.format(y)
+    assert result == "squeeze(x, 0)"
+
+    # Test with tuple axis
+    z = graph.squeeze(x, (0, 1))
+    result = pretty.format(z)
+    assert result == "squeeze(x, (0, 1))"
+
+
+def test_reduce_sum_pretty_printing():
+    """Test pretty printing of reduce_sum operation."""
+    x = graph.placeholder("x")
+    y = graph.reduce_sum(x, 0)
+
+    result = pretty.format(y)
+    assert result == "reduce_sum(x, 0)"
+
+    # Test with tuple axis
+    z = graph.reduce_sum(x, (0, 1))
+    result = pretty.format(z)
+    assert result == "reduce_sum(x, (0, 1))"
+
+
+def test_reduce_mean_pretty_printing():
+    """Test pretty printing of reduce_mean operation."""
+    x = graph.placeholder("x")
+    y = graph.reduce_mean(x, 0)
+
+    result = pretty.format(y)
+    assert result == "reduce_mean(x, 0)"
+
+    # Test with tuple axis
+    z = graph.reduce_mean(x, (0, 1))
+    result = pretty.format(z)
+    assert result == "reduce_mean(x, (0, 1))"
+
+
+def test_maximum_pretty_printing():
+    """Test pretty printing of maximum operation."""
+    x = graph.placeholder("x")
+    y = graph.constant(2.0)
+    z = graph.maximum(x, y)
+
+    result = pretty.format(z)
+    assert result == "maximum(x, 2.0)"
+
+
 def test_unhandled_node_type():
     """Test pretty printing of an unhandled node type."""
 
@@ -169,3 +259,36 @@ def test_unhandled_node_type():
     x = UnhandledNode()
     result = pretty.format(x)
     assert result == "<unknown:UnhandledNode>"
+
+
+def test_named_subexpressions_not_expanded():
+    """Test that named subexpressions aren't expanded in pretty printing."""
+    # Create a named subexpression
+    x = graph.placeholder("x")
+    y = graph.add(x, graph.constant(1.0))
+    y.name = "y"  # Give the subexpression a name
+
+    # Use the named subexpression in a larger expression
+    z = graph.multiply(y, graph.constant(2.0))
+
+    # The pretty-printed result should use the name rather than expanding
+    result = pretty.format(z)
+    assert (
+        result == "y * 2.0"
+    )  # Should use y's name, not expand it to "(x + 1.0) * 2.0"
+
+    # Verify with more complex nested expressions
+    a = graph.exp(y)
+    a.name = "a"
+    b = graph.where(graph.placeholder("cond"), a, graph.constant(3.0))
+
+    result = pretty.format(b)
+    assert result == "where(cond, a, 3.0)"  # Should use a's name, not expand it
+
+    # Test with multiple levels of named expressions
+    c = graph.add(b, graph.constant(4.0))
+    c.name = "c"
+    d = graph.subtract(c, graph.constant(5.0))
+
+    result = pretty.format(d)
+    assert result == "c - 5.0"  # Should use c's name, not expand further


### PR DESCRIPTION
This fix ensures we don't recursively expand the whole formula but rather we print formulae that match quite closely what the user has written, thus helping debugging.

While there, make sure pretty handles all node types.

Also, ensure we have full testing coverage.