### PR TITLE
feat(yakof): add the trafficmodel package

### DIFF
--- a/tests/trafficmodel/test_model.py
+++ b/tests/trafficmodel/test_model.py
@@ -1,0 +1,95 @@
+"""Tests for the yakof.trafficmodel package."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from yakof.frontend import graph
+from yakof.numpybackend import executor
+from yakof import trafficmodel
+
+
+def test_traffic_model():
+    # Build model with standard inputs
+    inputs = trafficmodel.Inputs()
+    model = trafficmodel.build(inputs)
+
+    # Set up test input values
+    hours = np.array([6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0])
+    base_demand = np.array([10.0, 20.0, 50.0, 30.0, 15.0, 10.0, 10.0])
+    price = np.array([1.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0])
+    price_sensitivity = np.array([0.05, 0.1, 0.15])
+
+    # Set up state
+    state = executor.State(
+        values={
+            inputs.base_demand.node: base_demand,
+            inputs.price.node: price,
+            inputs.hours.node: hours,
+            inputs.price_sensitivity.node: price_sensitivity,
+        }
+    )
+
+    # Evaluate the model
+    for node in model.nodes:
+        executor.evaluate(state, node)
+
+    # Extract results
+    price_affected_demand = state.values[model.price_affected_demand.node]
+    demand_after_removal = state.values[model.demand_after_removal.node]
+    actual_demand = state.values[model.actual_demand.node]
+
+    # Calculate expected results (simplified version for testing)
+    # Peak hours are 7-9, so indices 1 and 2
+
+    # Expected price effect calculation
+    expected_price_effect = np.zeros((7, 3))
+    for i in range(7):
+        for j in range(3):
+            expected_price_effect[i, j] = 1.0 - price_sensitivity[j] * np.log(
+                price[i] / inputs.base_price
+            )
+
+    expected_price_affected = base_demand[:, np.newaxis] * expected_price_effect
+
+    # Verify shape
+    assert price_affected_demand.shape == (
+        7,
+        3,
+    ), "Price affected demand has incorrect shape"
+
+    # Check results match expected values (with tolerance for floating point)
+    np.testing.assert_allclose(
+        price_affected_demand, expected_price_affected, rtol=1e-5
+    )
+
+    # Verify that demand is reduced at peak and increased at shoulders
+    # Peak hours: 7-9 (indices 1, 2)
+    # Check that actual_demand is less than price_affected_demand in peak hours
+    for i in [1, 2]:  # Peak hours
+        for j in range(3):  # All ensemble dimensions
+            assert (
+                demand_after_removal[i, j] < price_affected_demand[i, j]
+            ), f"Demand at peak hour {hours[i]} should be reduced"
+
+    # Check total conservation of demand (within floating point tolerance)
+    total_original = np.sum(price_affected_demand)
+    total_final = np.sum(actual_demand)
+    np.testing.assert_allclose(
+        total_original,
+        total_final,
+        rtol=1e-5,
+        err_msg="Total demand should be conserved after shifting",
+    )
+
+    # Additional checks for the time-shifting effect
+    # Verify early shifting: Hour 6 should have increased demand
+    assert np.all(
+        actual_demand[0, :] > price_affected_demand[0, :]
+    ), "Early shifting should increase demand in pre-peak hour"
+
+    # Verify late shifting: Hour 9 should have increased demand
+    assert np.all(
+        actual_demand[3, :] > price_affected_demand[3, :]
+    ), "Late shifting should increase demand in post-peak hour"

--- a/yakof/trafficmodel/__init__.py
+++ b/yakof/trafficmodel/__init__.py
@@ -1,0 +1,247 @@
+"""
+Traffic Model
+=============
+
+This module models traffic demand patterns with price sensitivity and time-shifting effects.
+It simulates how demand changes in response to pricing and how peak demand gets shifted to
+shoulder periods (before and after peaks).
+
+The model operates in multiple dimensions:
+- Time: Represents different hours of the day
+- Ensemble: Represents different scenarios or population segments with varying sensitivities
+- Field: Combined time and ensemble dimensions for full modeling
+
+The traffic model captures how demand is influenced by:
+1. Price effects: Higher prices reduce demand based on price sensitivity
+2. Time-shifting: Peak-period demand partially shifts to shoulder periods
+"""
+
+from dataclasses import dataclass
+
+from ..frontend import abstract, autonaming, bases, graph, linearize, morphisms
+
+# Axes
+time_axis_id, ensemble_axis_id = morphisms.generate_canonical_axes(2)
+
+# Bases
+ScalarBasis = bases.Scalar
+
+
+class TimeBasis:
+    """Represents the time dimension in the traffic model."""
+
+    axes = (time_axis_id,)
+
+
+class EnsembleBasis:
+    """Represents different scenarios or population segments with varying sensitivities."""
+
+    axes = (ensemble_axis_id,)
+
+
+class FieldBasis:
+    """Combined time and ensemble dimensions for the complete modeling space."""
+
+    axes = (time_axis_id, ensemble_axis_id)
+
+
+# Spaces
+scalar_space = abstract.TensorSpace(ScalarBasis())
+time_space = abstract.TensorSpace(TimeBasis())
+ensemble_space = abstract.TensorSpace(EnsembleBasis())
+field_space = abstract.TensorSpace(FieldBasis())
+
+# Scalar expansions
+expand_scalar_to_time = morphisms.ExpandDims(scalar_space, time_space)
+expand_scalar_to_ensemble = morphisms.ExpandDims(scalar_space, ensemble_space)
+expand_scalar_to_field = morphisms.ExpandDims(scalar_space, field_space)
+
+# Space expansions
+expand_time_to_field = morphisms.ExpandDims(time_space, field_space)
+expand_ensemble_to_field = morphisms.ExpandDims(ensemble_space, field_space)
+
+# Field projections
+project_field_to_time_using_sum = morphisms.ProjectUsingSum(field_space, time_space)
+project_field_to_ensemble_using_sum = morphisms.ProjectUsingSum(
+    field_space, ensemble_space
+)
+project_field_to_scalar_using_sum = morphisms.ProjectUsingSum(field_space, scalar_space)
+
+# Time/Ensemble projections
+project_time_to_scalar_using_sum = morphisms.ProjectUsingSum(time_space, scalar_space)
+project_ensemble_to_scalar_using_sum = morphisms.ProjectUsingSum(
+    ensemble_space, scalar_space
+)
+
+
+# Inputs
+@dataclass(frozen=True)
+class Inputs:
+    """Input parameters for the traffic model.
+
+    Attributes:
+        morning_peak_start: Start time of the morning peak period (hour of day)
+        morning_peak_end: End time of the morning peak period (hour of day)
+        base_price: Reference price level used for price sensitivity calculations
+        early_shift_rate: Fraction of peak demand that shifts to earlier periods
+        late_shift_rate: Fraction of peak demand that shifts to later periods
+        base_demand: Baseline demand over time before any modifications
+        price: Time-varying price level
+        hours: Time points for the model (hours of day)
+        price_sensitivity: Sensitivity of different population segments to price changes
+    """
+
+    morning_peak_start = 7.0
+    morning_peak_end = 9.0
+    base_price = 1.0
+    early_shift_rate = 0.3
+    late_shift_rate = 0.1
+    base_demand = time_space.placeholder("base_demand")
+    price = time_space.placeholder("price")
+    hours = time_space.placeholder("hours")
+    price_sensitivity = ensemble_space.placeholder("price_sensitivity")
+
+
+# Outputs
+@dataclass(frozen=True)
+class Outputs:
+    """Output values from the traffic model.
+
+    Attributes:
+        base_demand: Original demand pattern over time
+        price_affected_demand: Demand after applying price sensitivity effects
+        demand_after_removal: Demand after removing the shifted portion from peak periods
+        actual_demand: Final demand after all effects (price and time-shifting)
+        price: The price level used for calculations
+    """
+
+    # Output tensors
+    price_affected_demand: abstract.Tensor[FieldBasis]
+    demand_after_removal: abstract.Tensor[FieldBasis]
+    actual_demand: abstract.Tensor[FieldBasis]
+
+    # Plan to evaluate the whole graph in order
+    nodes: list[graph.Node]
+
+
+def build(inputs: Inputs) -> Outputs:
+    """Build the traffic model with price effects and time-shifting.
+
+    This function constructs the full traffic model, applying both price sensitivity
+    effects and time-shifting of peak demand to shoulder periods.
+
+    Args:
+        inputs: Model input parameters and placeholders
+
+    Returns:
+        Model outputs including the final demand pattern
+    """
+    # Auto-assign names to tensors to make debugging much easier
+    with autonaming.context():
+
+        # --- Time Space Calculations ---
+
+        # Define time windows
+        is_peak = (inputs.hours >= inputs.morning_peak_start) & (
+            inputs.hours < inputs.morning_peak_end
+        )
+        is_early_distribution_window = (
+            inputs.hours >= (inputs.morning_peak_start - 1.0)
+        ) & (inputs.hours < inputs.morning_peak_end)
+        is_late_distribution_window = (inputs.hours >= inputs.morning_peak_start) & (
+            inputs.hours < (inputs.morning_peak_end + 1.0)
+        )
+
+        # Count intervals in each window (for redistribution)
+        early_window_size = project_time_to_scalar_using_sum(
+            time_space.where(
+                is_early_distribution_window,
+                time_space.constant(1.0),
+                time_space.constant(0.0),
+            )
+        )
+        late_window_size = project_time_to_scalar_using_sum(
+            time_space.where(
+                is_late_distribution_window,
+                time_space.constant(1.0),
+                time_space.constant(0.0),
+            )
+        )
+
+        # --- Field Space Calculations ---
+
+        # Lift time series to field space
+        field_base_demand = expand_time_to_field(inputs.base_demand)
+        field_price = expand_time_to_field(inputs.price)
+        field_is_peak = expand_time_to_field(is_peak)
+        field_is_early_window = expand_time_to_field(is_early_distribution_window)
+        field_is_late_window = expand_time_to_field(is_late_distribution_window)
+        field_early_window_size = expand_scalar_to_field(early_window_size)
+        field_late_window_size = expand_scalar_to_field(late_window_size)
+
+        # Lift ensemble values to field space
+        field_price_sensitivity = expand_ensemble_to_field(inputs.price_sensitivity)
+
+        # First apply price effects
+        price_effect = 1.0 - field_price_sensitivity * field_space.log(
+            field_price / inputs.base_price
+        )
+        price_affected_demand = field_base_demand * price_effect
+
+        # Then apply time shifting to the price-affected demand
+        # Calculate peak demand and how much to remove
+        peak_demand = field_space.where(
+            field_is_peak,
+            price_affected_demand,
+            field_space.constant(0.0),
+        )
+
+        # Remove demand from peak
+        fraction_to_remove = inputs.early_shift_rate + inputs.late_shift_rate
+        demand_after_removal = field_space.where(
+            field_is_peak,
+            price_affected_demand * (1.0 - fraction_to_remove),
+            price_affected_demand,
+        )
+
+        # Calculate total demand to shift to each shoulder
+        total_early_shift = peak_demand * inputs.early_shift_rate
+        total_late_shift = peak_demand * inputs.late_shift_rate
+
+        # Calculate total shift amounts
+        total_early = project_field_to_ensemble_using_sum(total_early_shift)
+        total_late = project_field_to_ensemble_using_sum(total_late_shift)
+
+        # Distribute to shoulder periods
+        field_total_early = expand_ensemble_to_field(total_early)
+        early_addition = field_space.where(
+            field_is_early_window,
+            field_total_early / field_early_window_size,
+            field_space.constant(0.0),
+        )
+
+        field_total_late = expand_ensemble_to_field(total_late)
+        late_addition = field_space.where(
+            field_is_late_window,
+            field_total_late / field_late_window_size,
+            field_space.constant(0.0),
+        )
+
+        # Final demand combines all the effects
+        actual_demand = demand_after_removal + early_addition + late_addition
+
+    # --- Output ---
+
+    # Linearize the execution plan
+    evaluation_plan = linearize.forest(
+        price_affected_demand.node,
+        demand_after_removal.node,
+        actual_demand.node,
+    )
+
+    return Outputs(
+        price_affected_demand=price_affected_demand,
+        demand_after_removal=demand_after_removal,
+        actual_demand=actual_demand,
+        nodes=evaluation_plan,
+    )


### PR DESCRIPTION
With this diff, we add to yakof the trafficmodel package. This model is ~equivalent to the one we originally wrote as the yakof.fieldspace package -- along with the traffic.py example -- except that this model uses the new frontend and the numpybackend and, also, it's reusable and tested.

This work is part of a plan to remove the yakof.fieldspace package and to update the existing traffic.py file to use the new code.