### PR TITLE
feat(frontend): add automatic enumeration support

### DIFF
--- a/tests/frontend/test_autoenum.py
+++ b/tests/frontend/test_autoenum.py
@@ -1,0 +1,186 @@
+"""Tests for the yakof.frontend.autoenum module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from yakof import atomic
+from yakof.frontend import abstract, autoenum, autonaming, bases, graph
+
+
+# Define test bases and spaces
+class TestBasis:
+    axes = (1000,)
+
+
+class OtherBasis:
+    axes = (2000,)
+
+
+@pytest.fixture
+def test_space():
+    return abstract.TensorSpace(TestBasis())
+
+
+@pytest.fixture
+def other_space():
+    return abstract.TensorSpace(OtherBasis())
+
+
+def test_enum_type_creation(test_space):
+    """Test creation of enum types."""
+    enum_type = autoenum.Type(test_space, "TestEnum")
+
+    assert enum_type.name == "TestEnum"
+    assert enum_type.space is test_space
+    assert enum_type.basevalue > 0
+    assert enum_type.basevalue % (1 << autoenum._shift) == 0  # Should be left-shifted
+
+
+def test_enum_value_creation(test_space):
+    """Test creation of enum values."""
+    enum_type = autoenum.Type(test_space, "TestEnum")
+    enum_value = autoenum.Value(enum_type, "TestValue")
+
+    assert enum_value.name == "TestValue"
+    assert (
+        enum_value.value & (enum_type.basevalue) == enum_type.basevalue
+    )  # Contains type's base value
+    assert isinstance(enum_value.tensor, abstract.Tensor)
+    assert enum_value.tensor.space is test_space
+
+
+def test_enum_value_uniqueness(test_space):
+    """Test that enum values in the same type have unique values."""
+    enum_type = autoenum.Type(test_space, "TestEnum")
+    value1 = autoenum.Value(enum_type, "Value1")
+    value2 = autoenum.Value(enum_type, "Value2")
+
+    assert value1.value != value2.value
+    assert isinstance(value1.tensor.node, graph.constant)
+    assert isinstance(value2.tensor.node, graph.constant)
+    assert value1.tensor.node.value != value2.tensor.node.value
+
+
+def test_enum_type_disjoint_ranges(test_space, other_space):
+    """Test that different enum types have disjoint value ranges."""
+    type1 = autoenum.Type(test_space, "Type1")
+    type2 = autoenum.Type(other_space, "Type2")
+
+    value1 = autoenum.Value(type1, "Value1")
+    value2 = autoenum.Value(type2, "Value2")
+
+    # Values from different enum types should have different ranges
+    assert (value1.value & type1.basevalue) != (value2.value & type2.basevalue)
+
+
+def test_autonaming_integration():
+    """Test integration with autonaming context."""
+    test_space = abstract.TensorSpace(TestBasis())
+
+    with autonaming.context():
+        weather_enum = autoenum.Type(test_space, "")
+        sunny = autoenum.Value(weather_enum, "")
+        cloudy = autoenum.Value(weather_enum, "")
+
+    assert weather_enum.name == "weather_enum"
+    assert sunny.name == "sunny"
+    assert cloudy.name == "cloudy"
+
+    # Tensor names should also be set
+    assert sunny.tensor.name == "sunny"
+    assert cloudy.tensor.name == "cloudy"
+
+
+def test_tensor_comparison(test_space):
+    """Test using enum values in tensor comparisons."""
+    enum_type = autoenum.Type(test_space, "TestEnum")
+    value1 = autoenum.Value(enum_type, "Value1")
+    value2 = autoenum.Value(enum_type, "Value2")
+
+    # Create a placeholder tensor in the same space
+    tensor = test_space.placeholder("test_tensor")
+
+    # Test tensor comparisons
+    eq_tensor1 = tensor == value1.tensor
+    eq_tensor2 = tensor == value2.tensor
+
+    # Verify the comparisons created equality operations
+    assert eq_tensor1.node.__class__.__name__ == "equal"
+    assert eq_tensor2.node.__class__.__name__ == "equal"
+
+    # Verify the correct values are being compared
+    assert eq_tensor1.node.right.value == value1.value
+    assert eq_tensor2.node.right.value == value2.value
+
+
+def test_many_enum_values():
+    """Test creating many enum values (not enough to hit the limit)."""
+    test_space = abstract.TensorSpace(TestBasis())
+    enum_type = autoenum.Type(test_space, "LargeEnum")
+
+    # Create a moderate number of values
+    values = [autoenum.Value(enum_type, f"Value{i}") for i in range(100)]
+
+    # Check they're all unique
+    unique_values = {v.value for v in values}
+    assert len(unique_values) == 100
+
+
+def test_value_id_overflow():
+    """Test that an error is raised when too many enum values are created."""
+    test_space = abstract.TensorSpace(TestBasis())
+    enum_type = autoenum.Type(test_space, "OverflowTest")
+
+    # Manually set the counter to near the limit
+    enum_type.gen.add((1 << autoenum._shift) - 3)
+
+    # Create two values (should work)
+    value1 = autoenum.Value(enum_type, "Value1")
+    value2 = autoenum.Value(enum_type, "Value2")
+
+    # Next one should raise an error
+    with pytest.raises(ValueError, match="Too many enum values"):
+        value3 = autoenum.Value(enum_type, "Value3")
+
+
+def test_id_generation():
+    """Test the _next_id helper function directly."""
+    counter = atomic.Int()
+
+    # Generate a few IDs
+    id1 = autoenum._next_id(counter)
+    id2 = autoenum._next_id(counter)
+    id3 = autoenum._next_id(counter)
+
+    assert id1 == 1
+    assert id2 == 2
+    assert id3 == 3
+
+    # Test overflow
+    counter.add((1 << autoenum._shift) - 3)
+    with pytest.raises(ValueError):
+        autoenum._next_id(counter)
+
+
+def test_type_parameter_consistency():
+    """Test that the generic type parameter correctly enforces type safety."""
+    # This test is primarily a compile-time check
+    # Here we're just verifying the attributes to ensure the code paths work
+
+    test_space = abstract.TensorSpace(TestBasis())
+    other_space = abstract.TensorSpace(OtherBasis())
+
+    test_enum = autoenum.Type(test_space, "TestEnum")
+    other_enum = autoenum.Type(other_space, "OtherEnum")
+
+    test_value = autoenum.Value(test_enum, "TestValue")
+    other_value = autoenum.Value(other_enum, "OtherValue")
+
+    # Verify space relationships
+    assert test_value.tensor.space is test_space
+    assert other_value.tensor.space is other_space
+
+    # The following would be type errors if actually attempted:
+    # bad_value = autoenum.Value[TestBasis](other_enum, "BadValue")
+    # test_tensor == other_value.tensor  # Would fail at compile-time

--- a/yakof/frontend/autoenum.py
+++ b/yakof/frontend/autoenum.py
@@ -1,0 +1,161 @@
+"""
+Enumeration Support
+===================
+
+This module contains code to generate automatically disjoint type-safe
+enumerations that can be integrated with tensor spaces.
+
+The module provides these abstractions:
+
+1. Type: an enumeration type associated with a tensor space. Each enum type
+has a disjoint range of integer values from other enum types.
+
+2. Value:Represents a specific value within an enumeration type. Each
+value has a unique integer representation and an associated tensor.
+
+We reserve 20 bits for the enumeration type ID and 20 bits for the value ID,
+which should provide plenty of enumeration space. When we're out of the
+enumeration space (i.e., we have used 20 bits), the code throws a ValueError.
+
+Type Parameters
+---------------
+
+E: The basis type of the tensor space associated with an enumeration.
+
+Usage Example
+-------------
+
+```python
+from yakof.frontend import abstract, autoenum, autonaming
+
+# Define spaces and enum types
+with autonaming.context():
+    weather_enum = autoenum.Type(weather_space, "")
+    SUNNY = autoenum.Value(weather_enum, "")
+    CLOUDY = autoenum.Value(weather_enum, "")
+
+    time_enum = autoenum.Type(time_space, "")
+    MORNING = autoenum.Value(time_enum, "")
+    EVENING = autoenum.Value(time_enum, "")
+
+# Use in expressions (type-safe)
+is_sunny = weather_tensor == SUNNY.tensor  # Valid
+is_morning = time_tensor == MORNING.tensor  # Valid
+# weather_tensor == MORNING.tensor  # Type error - different enum types
+```
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from .. import atomic
+from ..frontend import abstract
+
+
+_id_generator = atomic.Int()
+"""Atomic integer generator for unique enum type IDs."""
+
+
+_shift = 20
+"""Bit shift used to separate enum type IDs from value IDs within the type."""
+
+
+E = TypeVar("E")
+"""Type variable for tensor basis types, used by Type and Value."""
+
+
+def _next_id(gen: atomic.Int) -> int:
+    """Generate the next ID from an atomic counter with overflow protection.
+
+    Args:
+        gen: Atomic counter to increment for generating the next ID
+
+    Returns:
+        The next unique ID
+
+    Raises:
+        ValueError: If the counter exceeds the maximum allowed value
+    """
+    value = gen.add(1)
+    if value >= (1 << _shift):
+        raise ValueError("Too many enum values")
+    return value
+
+
+class Type(Generic[E]):
+    """A type-safe enumeration type bound to a tensor space.
+
+    Type Parameters:
+        E: The basis type of the associated tensor space.
+
+    Attributes:
+        space: The tensor space associated with this enumeration type.
+        basevalue: Unique ID for this enum type.
+        gen: Atomic counter for generating unique value IDs within this type.
+
+    Args:
+        space: The tensor space to associate with this enum type.
+        name: name for the enum type (leave empty if using autonaming).
+    """
+
+    def __init__(self, space: abstract.TensorSpace[E], name: str) -> None:
+        self._name = name
+        self.basevalue = _next_id(_id_generator) << _shift
+        self.gen = atomic.Int()
+        self.space = space
+
+    # autonaming.Namer protocol implementation
+    def implements_namer(self) -> None:
+        """This method is part of the autonaming.Namer protocol"""
+
+    @property
+    def name(self) -> str:
+        """This method is part of the autonaming.Namer protocol"""
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """This method is part of the autonaming.Namer protocol"""
+        self._name = value
+
+
+class Value(Generic[E]):
+    """A specific value within an enumeration type.
+
+    Each value has a unique integer representation that:
+    1. Is disjoint from values in other enum types
+    2. Can be used in tensor computations via the .tensor property
+
+    Type Parameters:
+        E: The basis type of the tensor space from the parent enum type.
+
+    Attributes:
+        value: Integer representation of this enum value.
+        tensor: Constant tensor representation in the parent's tensor space.
+
+    Args:
+        parent: The enum type this value belongs to.
+        name: name for this value (leave empty if using autonaming).
+    """
+
+    def __init__(self, parent: Type[E], name: str) -> None:
+        self._type = parent
+        self.value = parent.basevalue | _next_id(parent.gen)
+        self.tensor = parent.space.constant(self.value, name=name)
+
+    # autonaming.Namer protocol implementation
+    def implements_namer(self) -> None:
+        """This method is part of the autonaming.Namer protocol"""
+
+    @property
+    def name(self) -> str:
+        """This method is part of the autonaming.Namer protocol"""
+        return self.tensor.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """This method is part of the autonaming.Namer protocol"""
+        self.tensor.name = value


### PR DESCRIPTION
This diff adds support for generating automatically disjoint enumerations bound to specific tensor spaces.

The typical usage is as follows:

```Python
with autonaming.context():
    weather_enum = autoenum.Type(weather_space, "")
    SUNNY = autoenum.Value(weather_enum, "")
    CLOUDY = autoenum.Value(weather_enum, "")

    time_enum = autoenum.Type(time_space, "")
    MORNING = autoenum.Value(time_enum, "")
    EVENING = autoenum.Value(time_enum, "")

is_sunny = weather_tensor == SUNNY.tensor  # Valid
is_morning = time_tensor == MORNING.tensor  # Valid
```

where `weather_enum` and `time_enum` use different 2^20 value spaces for storing enumerations. Each enumeration is a given value within the corresponding space. There's a TypeError when we use all the 2^20 space (arguably enough for us).

Each enum value is also automatically bound to a constant tensor with the proper type that can be used within the computation.