### PR TITLE
BREAKING CHANGE(executor): remove FLAG_BREAK_ON_NAMED_NODE

### DIFF
--- a/tests/numpybackend/test_executor.py
+++ b/tests/numpybackend/test_executor.py
@@ -296,9 +296,7 @@ def test_debug_flags(capsys, monkeypatch):
     named_node.name = "named_addition"
     plan = linearize.forest(named_node)
 
-    state = executor.State(
-        {x: np.array([1.0, 2.0, 3.0])}, flags=executor.FLAG_BREAK_ON_NAMED_NODE
-    )
+    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=executor.FLAG_BREAK)
     for node in plan:
         executor.evaluate(state, node)
 

--- a/tests/numpybackend/test_executor.py
+++ b/tests/numpybackend/test_executor.py
@@ -284,7 +284,7 @@ def test_debug_flags(capsys, monkeypatch):
     z = graph.add(x, graph.constant(5.0))
     plan = linearize.forest(z)
 
-    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=executor.FLAG_TRACE)
+    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=graph.NODE_FLAG_TRACE)
     for node in plan:
         executor.evaluate(state, node)
 
@@ -296,7 +296,7 @@ def test_debug_flags(capsys, monkeypatch):
     named_node.name = "named_addition"
     plan = linearize.forest(named_node)
 
-    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=executor.FLAG_BREAK)
+    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=graph.NODE_FLAG_BREAK)
     for node in plan:
         executor.evaluate(state, node)
 

--- a/yakof/numpybackend/executor.py
+++ b/yakof/numpybackend/executor.py
@@ -51,7 +51,7 @@ class State:
 
     Attributes:
         values: A dictionary caching the result of the computation.
-        flags: Bitmask containing debug flags (e.g., FLAG_BREAK).
+        flags: Bitmask containing debug flags (e.g., graph.FLAG_BREAK).
     """
 
     values: dict[graph.Node, np.ndarray]

--- a/yakof/numpybackend/executor.py
+++ b/yakof/numpybackend/executor.py
@@ -51,7 +51,7 @@ class State:
 
     Attributes:
         values: A dictionary caching the result of the computation.
-        flags: Bitmask containing debug flags (e.g., graph.FLAG_BREAK).
+        flags: Bitmask containing debug flags (e.g., graph.NODE_FLAG_BREAK).
     """
 
     values: dict[graph.Node, np.ndarray]

--- a/yakof/numpybackend/executor.py
+++ b/yakof/numpybackend/executor.py
@@ -25,13 +25,6 @@ from ..frontend import graph
 from . import debug, dispatch
 
 
-FLAG_BREAK_ON_NAMED_NODE = 1 << 0
-"""Configures the executor to break on nodes with a non-empty name."""
-
-FLAG_TRACE = 1 << 1
-"""Configures the executor to trace the computation."""
-
-
 class NodeValueNotFound(Exception):
     """Raised when a node value is not found in the state."""
 
@@ -58,7 +51,7 @@ class State:
 
     Attributes:
         values: A dictionary caching the result of the computation.
-        flags: Bitmask containing debug flags (e.g., FLAG_BREAK_ON_NAMED_NODE).
+        flags: Bitmask containing debug flags (e.g., FLAG_BREAK).
     """
 
     values: dict[graph.Node, np.ndarray]
@@ -111,7 +104,8 @@ def evaluate(state: State, node: graph.Node) -> np.ndarray:
         return state.values[node]
 
     # 2. check whether we need to trace this node
-    tracing = node.flags & graph.NODE_FLAG_TRACE != 0 or state.flags & FLAG_TRACE != 0
+    flags = node.flags | state.flags
+    tracing = flags & graph.NODE_FLAG_TRACE
     if tracing:
         debug.print_graph_node(node)
 
@@ -123,10 +117,7 @@ def evaluate(state: State, node: graph.Node) -> np.ndarray:
         debug.print_evaluated_node(result, cached=False)
 
     # 5. check whether we need to stop after evaluating this node
-    breaking = node.flags & graph.NODE_FLAG_BREAK != 0 or (
-        state.flags & FLAG_BREAK_ON_NAMED_NODE != 0 and node.name
-    )
-    if breaking:
+    if flags & graph.NODE_FLAG_BREAK != 0:
         input("executor: press any key to continue...")
         print("")
 


### PR DESCRIPTION
With complex models, this flag is confusing. Remove it and fall back to using the same flags used by the graph to avoid duplication. We need to gain more experience regarding what is actually useful when debugging before introducing extra debugging functionality.