### PR TITLE
fix(executor.State): conditionally print initial nodes

### DIFF
--- a/tests/numpybackend/test_executor.py
+++ b/tests/numpybackend/test_executor.py
@@ -672,3 +672,32 @@ def test_axis_operations():
 
         for node in invalid_plan:
             executor.evaluate(invalid_state, node)
+
+
+def test_state_post_init_tracing(capsys):
+    """Test that State.__post_init__ traces initial values when NODE_FLAG_TRACE is set."""
+    # Create nodes
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+
+    # Test data
+    x_val = np.array([1.0, 2.0, 3.0])
+    y_val = np.array([4.0, 5.0, 6.0])
+
+    # Create state with tracing flag
+    state = executor.State(
+        {x: x_val, y: y_val},
+        flags=graph.NODE_FLAG_TRACE
+    )
+
+    # Check that tracing output was generated during initialization
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Verify that both nodes were traced in the output
+    assert f"name: {x.name}" in output
+    assert f"name: {y.name}" in output
+    assert "=== begin tracepoint ===" in output
+
+    # Verify the cached indication is shown
+    assert "cached: True" in output

--- a/tests/numpybackend/test_executor.py
+++ b/tests/numpybackend/test_executor.py
@@ -685,10 +685,7 @@ def test_state_post_init_tracing(capsys):
     y_val = np.array([4.0, 5.0, 6.0])
 
     # Create state with tracing flag
-    state = executor.State(
-        {x: x_val, y: y_val},
-        flags=graph.NODE_FLAG_TRACE
-    )
+    state = executor.State({x: x_val, y: y_val}, flags=graph.NODE_FLAG_TRACE)
 
     # Check that tracing output was generated during initialization
     captured = capsys.readouterr()

--- a/yakof/numpybackend/executor.py
+++ b/yakof/numpybackend/executor.py
@@ -49,6 +49,9 @@ class State:
     Make sure to provide values for placeholder nodes ahead of the evaluation
     by initializing the `values` dictionary accordingly.
 
+    Note that, if graph.NODE_FLAG_TRACE is set, the executor will print the
+    nodes provided to the constructor in its __post_init__ method.
+
     Attributes:
         values: A dictionary caching the result of the computation.
         flags: Bitmask containing debug flags (e.g., graph.NODE_FLAG_BREAK).
@@ -56,6 +59,13 @@ class State:
 
     values: dict[graph.Node, np.ndarray]
     flags: int = 0
+
+    def __post_init__(self):
+        if self.flags & graph.NODE_FLAG_TRACE != 0:
+            nodes = sorted(self.values.keys(), key=lambda n: n.id)
+            for node in nodes:
+                debug.print_graph_node(node)
+                debug.print_evaluated_node(self.values[node], cached=True)
 
     def get_node_value(self, node: graph.Node) -> np.ndarray:
         """Helper function to access the value associated with a node.

--- a/yakof/numpybackend/executor.py
+++ b/yakof/numpybackend/executor.py
@@ -49,7 +49,7 @@ class State:
     Make sure to provide values for placeholder nodes ahead of the evaluation
     by initializing the `values` dictionary accordingly.
 
-    Note that, if graph.NODE_FLAG_TRACE is set, the executor will print the
+    Note that, if graph.NODE_FLAG_TRACE is set, the State will print the
     nodes provided to the constructor in its __post_init__ method.
 
     Attributes:


### PR DESCRIPTION
When the flags contain `graph.NODE_FLAG_TRACE`, we print the initial nodes as part of the `State.__post_init__` method.

This helps to debug, because it allows us to see what is the initial state with which we evaluate a model.