### PR TITLE
feat(yakof): add the minisimulator package

### DIFF
--- a/tests/minisimulator/test_minisimulator.py
+++ b/tests/minisimulator/test_minisimulator.py
@@ -1,0 +1,250 @@
+"""Tests for the yakof.minisimulator package."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from numpy.testing import assert_array_equal, assert_allclose
+
+import pytest
+import numpy as np
+
+from yakof.frontend import graph
+from yakof import minisimulator
+
+
+class TestLinearRange:
+    def test_init(self):
+        # Test successful initialization
+        lr = minisimulator.LinearRange(0, 10, 5)
+        assert lr.start == 0
+        assert lr.stop == 10
+        assert lr.points == 5
+
+    def test_validation(self):
+        # Test invalid parameters
+        with pytest.raises(ValueError, match="stop must be greater than start"):
+            minisimulator.LinearRange(10, 5)
+
+        with pytest.raises(ValueError, match="stop must be greater than start"):
+            minisimulator.LinearRange(10, 10)
+
+        with pytest.raises(ValueError, match="points must be at least 2"):
+            minisimulator.LinearRange(0, 10, 1)
+
+    def test_linspace(self):
+        # Test linspace method
+        lr = minisimulator.LinearRange(0, 10, 5)
+        expected = np.linspace(0, 10, 5)
+        result = lr.linspace()
+        assert_array_equal(result, expected)
+
+
+class TestNormalDistribution:
+    def test_init(self):
+        nd = minisimulator.NormalDistribution(0, 1)
+        assert nd.mean == 0
+        assert nd.std == 1
+
+    def test_sample_shape(self):
+        # Test sample method returns correct shape
+        nd = minisimulator.NormalDistribution(0, 1)
+        samples = nd.sample((10,))
+        assert samples.shape == (10,)
+
+        samples = nd.sample((5, 3))
+        assert samples.shape == (5, 3)
+
+    def test_support_size(self):
+        # Test support_size method
+        nd = minisimulator.NormalDistribution(0, 1)
+        assert nd.support_size() is None
+
+
+class TestUniformDistribution:
+    def test_init(self):
+        ud = minisimulator.UniformDistribution(0, 10)
+        assert ud.low == 0
+        assert ud.high == 10
+
+    def test_sample_shape(self):
+        # Test sample method returns correct shape
+        ud = minisimulator.UniformDistribution(0, 10)
+        samples = ud.sample((10,))
+        assert samples.shape == (10,)
+
+        samples = ud.sample((5, 3))
+        assert samples.shape == (5, 3)
+
+    def test_sample_range(self):
+        # Test samples are within the specified range
+        ud = minisimulator.UniformDistribution(5, 15)
+        samples = ud.sample((1000,))
+        assert np.all(samples >= 5)
+        assert np.all(samples < 15)
+
+    def test_support_size(self):
+        # Test support_size method
+        ud = minisimulator.UniformDistribution(0, 10)
+        assert ud.support_size() is None
+
+
+class TestDiscreteDistribution:
+    def test_init(self):
+        dd = minisimulator.DiscreteDistribution([1, 2, 3], [0.2, 0.3, 0.5])
+        assert dd.choices == [1, 2, 3]
+        assert dd.probabilities == [0.2, 0.3, 0.5]
+
+    def test_with_uniform_probabilities(self):
+        dd = minisimulator.DiscreteDistribution.with_uniform_probabilities([1, 2, 3])
+        assert dd.choices == [1, 2, 3]
+        assert dd.probabilities == [1/3, 1/3, 1/3]
+
+    def test_with_discrete_probabilities(self):
+        dd = minisimulator.DiscreteDistribution.with_discrete_probabilities([(1, 0.2), (2, 0.3), (3, 0.5)])
+        assert dd.choices == [1, 2, 3]
+        assert dd.probabilities == [0.2, 0.3, 0.5]
+
+    def test_sample_shape(self):
+        dd = minisimulator.DiscreteDistribution([1, 2, 3], [0.2, 0.3, 0.5])
+        samples = dd.sample((10,))
+        assert samples.shape == (10,)
+
+        samples = dd.sample((5, 3))
+        assert samples.shape == (5, 3)
+
+    def test_sample_values(self):
+        # Test that samples contain only values from choices
+        dd = minisimulator.DiscreteDistribution([1, 2, 3], [0.2, 0.3, 0.5])
+        samples = dd.sample((1000,))
+        assert set(np.unique(samples)).issubset({1, 2, 3})
+
+    def test_support_size(self):
+        dd = minisimulator.DiscreteDistribution([1, 2, 3], [0.2, 0.3, 0.5])
+        assert dd.support_size() == 3
+
+
+class TestConstantDistribution:
+    def test_init(self):
+        # Test with different types
+        cd_float = minisimulator.ConstantDistribution(5.0)
+        assert cd_float.value == 5.0
+
+        cd_int = minisimulator.ConstantDistribution(5)
+        assert cd_int.value == 5
+
+        cd_bool = minisimulator.ConstantDistribution(True)
+        assert cd_bool.value is True
+
+    def test_sample(self):
+        cd = minisimulator.ConstantDistribution(5.0)
+        samples = cd.sample((10,))
+        assert_array_equal(samples, np.full((10,), 5.0))
+
+        samples = cd.sample((3, 4))
+        assert_array_equal(samples, np.full((3, 4), 5.0))
+
+    def test_support_size(self):
+        cd = minisimulator.ConstantDistribution(5.0)
+        assert cd.support_size() == 1
+
+
+class TestModelArgumentsBuilder:
+    def setup_method(self):
+        # Create mock nodes for testing
+        self.node1 = graph.Node("node1")
+        self.node2 = graph.Node("node2")
+        self.node3 = graph.Node("node3")
+        self.node4 = graph.Node("node4")
+
+    def test_add_linear_range(self):
+        builder = minisimulator.ModelArgumentsBuilder()
+        lr = minisimulator.LinearRange(0, 10, 5)
+        builder.add(self.node1, lr)
+        assert builder.params[self.node1] == lr
+
+    def test_add_distribution(self):
+        builder = minisimulator.ModelArgumentsBuilder()
+        nd = minisimulator.NormalDistribution(0, 1)
+        builder.add(self.node1, nd)
+        assert builder.params[self.node1] == nd
+
+    def test_build_with_linear_range(self):
+        builder = minisimulator.ModelArgumentsBuilder()
+        lr = minisimulator.LinearRange(0, 10, 5)
+        builder.add(self.node1, lr)
+
+        result = builder.build(10)
+        assert self.node1 in result
+        assert_array_equal(result[self.node1], np.linspace(0, 10, 5))
+
+    def test_build_with_distribution(self):
+        # Using a constant distribution for predictable results in tests
+        builder = minisimulator.ModelArgumentsBuilder()
+        cd = minisimulator.ConstantDistribution(5.0)
+        builder.add(self.node1, cd)
+
+        result = builder.build(10)
+        assert self.node1 in result
+        assert_array_equal(result[self.node1], np.full((10,), 5.0))
+
+    def test_build_with_mixed_parameters(self):
+        builder = minisimulator.ModelArgumentsBuilder()
+
+        # Add a linear range
+        lr = minisimulator.LinearRange(0, 10, 5)
+        builder.add(self.node1, lr)
+
+        # Add different distributions
+        cd = minisimulator.ConstantDistribution(5.0)
+        builder.add(self.node2, cd)
+
+        dd = minisimulator.DiscreteDistribution.with_uniform_probabilities([1, 2, 3])
+        builder.add(self.node3, dd)
+
+        ud = minisimulator.UniformDistribution(0, 1)
+        builder.add(self.node4, ud)
+
+        # Build with ensemble size 20
+        result = builder.build(20)
+
+        # Check each parameter
+        assert self.node1 in result
+        assert_array_equal(result[self.node1], np.linspace(0, 10, 5))
+
+        assert self.node2 in result
+        assert_array_equal(result[self.node2], np.full((20,), 5.0))
+
+        assert self.node3 in result
+        assert result[self.node3].shape == (20,)
+        assert set(np.unique(result[self.node3])).issubset({1, 2, 3})
+
+        assert self.node4 in result
+        assert result[self.node4].shape == (20,)
+        assert np.all(result[self.node4] >= 0)
+        assert np.all(result[self.node4] < 1)
+
+
+# Test that the Distribution protocol is working correctly
+def test_distribution_protocol():
+    # Create instances of each distribution
+    nd = minisimulator.NormalDistribution(0, 1)
+    ud = minisimulator.UniformDistribution(0, 10)
+    dd = minisimulator.DiscreteDistribution([1, 2, 3], [0.2, 0.3, 0.5])
+    cd = minisimulator.ConstantDistribution(5.0)
+
+    # Check that they satisfy the protocol
+    assert isinstance(nd, minisimulator.Distribution)
+    assert isinstance(ud, minisimulator.Distribution)
+    assert isinstance(dd, minisimulator.Distribution)
+    assert isinstance(cd, minisimulator.Distribution)
+
+    # Test the common interface methods
+    assert nd.sample((5,)).shape == (5,)
+    assert ud.sample((5,)).shape == (5,)
+    assert dd.sample((5,)).shape == (5,)
+    assert cd.sample((5,)).shape == (5,)
+
+    assert nd.support_size() is None
+    assert ud.support_size() is None
+    assert dd.support_size() == 3
+    assert cd.support_size() == 1

--- a/tests/minisimulator/test_minisimulator.py
+++ b/tests/minisimulator/test_minisimulator.py
@@ -97,10 +97,12 @@ class TestDiscreteDistribution:
     def test_with_uniform_probabilities(self):
         dd = minisimulator.DiscreteDistribution.with_uniform_probabilities([1, 2, 3])
         assert dd.choices == [1, 2, 3]
-        assert dd.probabilities == [1/3, 1/3, 1/3]
+        assert dd.probabilities == [1 / 3, 1 / 3, 1 / 3]
 
     def test_with_discrete_probabilities(self):
-        dd = minisimulator.DiscreteDistribution.with_discrete_probabilities([(1, 0.2), (2, 0.3), (3, 0.5)])
+        dd = minisimulator.DiscreteDistribution.with_discrete_probabilities(
+            [(1, 0.2), (2, 0.3), (3, 0.5)]
+        )
         assert dd.choices == [1, 2, 3]
         assert dd.probabilities == [0.2, 0.3, 0.5]
 

--- a/yakof/minisimulator/__init__.py
+++ b/yakof/minisimulator/__init__.py
@@ -1,0 +1,310 @@
+"""
+Minimal Simulator
+=================
+
+This package implements a minimal simulator for digital twins modeling. It provides
+the essential functionality to define context variables for a given model and to
+populate the ensemble dimension with appropriate values.
+
+The simulator is intentionally "minimal" - it implements only the core functionality
+needed to demonstrate integration capabilities with more complex systems without
+reproducing the full complexity of the `dt-model` package. This focused approach
+allows for a lightweight integration demonstration while maintaining extensibility
+for more sophisticated implementations.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence, runtime_checkable, Optional
+
+import numpy as np
+
+from ..frontend import graph
+
+
+@dataclass(frozen=True)
+class LinearRange:
+    """Linear range to explore in a parameter space.
+
+    Defines a one-dimensional range of values to be explored during simulation,
+    creating evenly spaced points between the start and stop values.
+
+    Args:
+        start: Starting value of the range
+        stop: Ending value of the range (must be greater than start)
+        points: Number of points to sample (default: 100, minimum: 2)
+
+    Raises:
+        ValueError: If stop <= start or if points < 2
+    """
+
+    start: float
+    stop: float
+    points: int = 100
+
+    def __post_init__(self):
+        if self.stop <= self.start:
+            raise ValueError("stop must be greater than start")
+        if self.points < 2:
+            raise ValueError("points must be at least 2")
+
+    def linspace(self) -> np.ndarray:
+        """Create linear space array for this range.
+
+        Returns:
+            numpy.ndarray: Array of evenly spaced values from start to stop,
+                          with the specified number of points.
+        """
+        return np.linspace(self.start, self.stop, self.points)
+
+
+@runtime_checkable
+class Distribution(Protocol):
+    """Protocol for parameter distributions.
+
+    Defines the interface for probability distributions used in ensemble simulations.
+    Any class implementing this protocol can be used to generate random samples
+    for parameter variation across ensemble members.
+
+    Methods:
+        sample: Generate random samples from the distribution with the given shape.
+        support_size: Return the number of distinct values in the distribution's support,
+                     or None if the support is infinite or uncountable.
+    """
+
+    def sample(self, size: tuple[int, ...]) -> np.ndarray: ...
+
+    def support_size(self) -> Optional[int]: ...
+
+
+@dataclass(frozen=True)
+class NormalDistribution:
+    """Normal (Gaussian) distribution.
+
+    Represents a normal probability distribution for ensemble parameter variation.
+
+    Args:
+        mean: Center of the distribution (expected value)
+        std: Standard deviation (spread or width of the distribution)
+    """
+
+    mean: float
+    std: float
+
+    def sample(self, size: tuple[int, ...]) -> np.ndarray:
+        """Generate samples from a normal distribution.
+
+        Args:
+            size: Shape of the output array
+
+        Returns:
+            numpy.ndarray: Random samples with the specified shape, drawn
+                          from a normal distribution with the given mean and std.
+        """
+        return np.random.normal(self.mean, self.std, size=size)
+
+    def support_size(self) -> Optional[int]:
+        """Return the size of the distribution's support.
+
+        Returns:
+            None: Normal distributions have uncountable, infinite support
+        """
+        return None
+
+
+@dataclass(frozen=True)
+class UniformDistribution:
+    """Uniform distribution.
+
+    Represents a uniform probability distribution where all values in the
+    specified range have equal probability of being sampled.
+
+    Args:
+        low: Lower boundary of the distribution range (inclusive)
+        high: Upper boundary of the distribution range (exclusive)
+    """
+
+    low: float
+    high: float
+
+    def sample(self, size: tuple[int, ...]) -> np.ndarray:
+        """Generate samples from a uniform distribution.
+
+        Args:
+            size: Shape of the output array
+
+        Returns:
+            numpy.ndarray: Random samples with the specified shape, drawn
+                          from a uniform distribution between low and high.
+        """
+        return np.random.uniform(self.low, self.high, size=size)
+
+    def support_size(self) -> Optional[int]:
+        """Return the size of the distribution's support.
+
+        Returns:
+            None: Uniform continuous distributions have uncountable, infinite support
+        """
+        return None
+
+
+@dataclass(frozen=True)
+class DiscreteDistribution:
+    """Discrete distribution.
+
+    Represents a discrete probability distribution where samples are drawn from
+    a finite set of possible values with specified probabilities.
+
+    Args:
+        choices: Sequence of possible values to sample from
+        probabilities: Sequence of probabilities corresponding to each choice
+                      (must sum to 1.0)
+    """
+
+    choices: Sequence[int]
+    probabilities: Sequence[float]
+
+    @staticmethod
+    def with_uniform_probabilities(values: Sequence[int]) -> DiscreteDistribution:
+        """Create a DiscreteDistribution with uniform probabilities.
+
+        This factory method simplifies creation of discrete distributions where
+        all values have equal probability of being sampled.
+
+        Args:
+            values: Sequence of possible values to sample from
+
+        Returns:
+            DiscreteDistribution: A new discrete distribution with uniform probabilities
+        """
+        return DiscreteDistribution(
+            choices=values,
+            probabilities=[1.0 / len(values)] * len(values),
+        )
+
+    @staticmethod
+    def with_discrete_probabilities(
+        values: Sequence[tuple[int, float]]
+    ) -> DiscreteDistribution:
+        """Create a DiscreteDistribution with specified probabilities.
+
+        This factory method simplifies creation of discrete distributions when values
+        and their corresponding probabilities are stored as pairs.
+
+        Args:
+            values: Sequence of (value, probability) tuples
+
+        Returns:
+            DiscreteDistribution: A new discrete distribution with values and probabilities
+                                  extracted from the provided pairs
+        """
+        return DiscreteDistribution(
+            choices=[value for value, _ in values],
+            probabilities=[prob for _, prob in values],
+        )
+
+    def sample(self, size: tuple[int, ...]) -> np.ndarray:
+        """Generate samples from a discrete distribution.
+
+        Args:
+            size: Shape of the output array
+
+        Returns:
+            numpy.ndarray: Random samples with the specified shape, drawn
+                          from the discrete distribution according to the
+                          specified probabilities.
+        """
+        return np.random.choice(
+            self.choices,
+            size=size,
+            p=self.probabilities,
+            replace=True,
+        )
+
+    def support_size(self) -> int:
+        """Return the size of the distribution's support.
+
+        Returns:
+            int: The number of distinct possible values (choices) in this discrete distribution
+        """
+        return len(self.choices)
+
+
+@dataclass(frozen=True)
+class ConstantDistribution:
+    """A distribution that always returns the same value.
+
+    This represents a deterministic parameter in an otherwise
+    stochastic ensemble - equivalent to a Dirac delta function.
+
+    Args:
+        value: The constant value to be returned by all samples
+
+    """
+
+    value: float | int | bool
+
+    def sample(self, size: tuple[int, ...]) -> np.ndarray:
+        """Generate an array filled with the constant value.
+
+        Args:
+            size: Shape of the output array
+
+        Returns:
+            numpy.ndarray: Array of specified shape filled with the constant value
+        """
+        return np.full(size, self.value)
+
+    def support_size(self) -> int:
+        """Return the size of the distribution's support.
+
+        Returns:
+            int: Always 1 for constant distributions, which have a single value
+        """
+        return 1
+
+
+class ModelArgumentsBuilder:
+    """Allows to programmatically build the model arguments.
+
+    Attributes:
+        params: A dictionary mapping nodes to distributions or linear ranges
+    """
+
+    def __init__(self):
+        self.params: dict[graph.Node, Distribution | LinearRange] = {}
+
+    def add(self, node: graph.Node, dlr: Distribution | LinearRange) -> None:
+        """Add a distribution or linear range for a given node.
+
+        Args:
+            node: The node to associate with the distribution
+            distr: The Distribution or LinearRange for generating values
+        """
+        self.params[node] = dlr
+
+    def build(self, space_size: int) -> dict[graph.Node, np.ndarray]:
+        """Build the model arguments by sampling values from the specified distributions.
+
+        Args:
+            space_size: The size of the ensemble space (number of samples to generate)
+
+        Returns:
+            dict[graph.Node, np.ndarray]: A dictionary mapping nodes to arrays of sampled values
+        """
+
+        # 1. create an empty dictionary to store the results
+        result: dict[graph.Node, np.ndarray] = {}
+
+        # 2. insert the linear ranges and the distributions
+        for node, lrange in self.params.items():
+            if isinstance(lrange, LinearRange):
+                result[node] = lrange.linspace()
+                continue
+            result[node] = lrange.sample((space_size,))
+
+        # 3. return the results dictionary
+        return result


### PR DESCRIPTION
The minisimulator package implements a naive minimal simulator allowing us to generate the input space parameters.

The actual `dt-model` package implements a better model.

Here we need a simplified model to show that we can integrate with the more complex code in the `dt-model` without having to deal with all the `dt-model` complexity.