### PR TITLE
feat: add dt_model emulation layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "yakof"
 version = "0.1.0"
 description = "A technology demonstrator for sustainability modeling"
 requires-python = "==3.11.11"
-dependencies = ["dt-model", "numpy", "sympy"]
+dependencies = ["scipy", "dt-model", "numpy", "sympy"]
 license = "Apache-2.0"
 
 [build-system]

--- a/tests/dtlang/__init__.py
+++ b/tests/dtlang/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the yakof.dtlang package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/dtlang/test_constraint.py
+++ b/tests/dtlang/test_constraint.py
@@ -1,0 +1,57 @@
+"""Tests for the yakof.dtlang.constraint module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yakof.dtlang import constraint
+from yakof.dtlang import geometry
+
+from scipy import stats
+
+import numpy as np
+
+
+def test_constraint_assign_tensors():
+    """Make sure that we can safely assign tensors to the constraint."""
+
+    a = geometry.space.placeholder("a")
+    b = geometry.space.placeholder("b")
+    c = constraint.Constraint(a, b)
+    assert c.usage == a
+    assert c.capacity == b
+
+
+def test_constraint_assign_distribution():
+    """Make sure that we can assign a distribution capacity."""
+    a = geometry.space.placeholder("a")
+    b = stats.uniform()
+    c = constraint.Constraint(a, b)
+    assert c.usage == a
+    assert c.capacity == b
+
+
+def test_constraint_with_name():
+    """Test constraint initialization with a name."""
+    a = geometry.space.placeholder("a")
+    b = geometry.space.placeholder("b")
+    c = constraint.Constraint(a, b, name="test_constraint")
+
+    assert c.name == "test_constraint"
+    assert c.usage == a
+    assert c.capacity == b
+
+
+def test_constraint_protocol():
+    """Test the CumulativeDistribution protocol compatibility."""
+
+    class TestDistribution:
+        def cdf(self, x, *args, **kwds):
+            return 0.5 if isinstance(x, float) else np.ones_like(x) * 0.5
+
+    # Check if our test class is recognized as a CumulativeDistribution
+    test_dist = TestDistribution()
+    assert isinstance(test_dist, constraint.CumulativeDistribution)
+
+    # Use it in a constraint
+    a = geometry.space.placeholder("a")
+    c = constraint.Constraint(a, test_dist)
+    assert c.capacity is test_dist

--- a/tests/dtlang/test_context.py
+++ b/tests/dtlang/test_context.py
@@ -1,0 +1,81 @@
+"""Tests for the yakof.dtlang.context module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yakof.dtlang import context, geometry
+from yakof.frontend import graph
+
+import pytest
+
+
+def test_categorical_context_variable():
+    """Make sure CategoricalContextVariable is working as intended."""
+
+    # Make sure the construct raises if the values are empty
+    with pytest.raises(ValueError):
+        _ = context.CategoricalContextVariable("ccv", {})
+
+    # Create a proper variable
+    ccv = context.CategoricalContextVariable(
+        "ccv", {"a": 1 / 3, "b": 1 / 3, "c": 1 / 3}
+    )
+
+    # Make sure the support size is correct
+    assert ccv.support_size() == 3
+
+    # Make sure equality comparison returns a geometry.Tensor
+    comparison = ccv == "a"
+    assert isinstance(comparison.node, graph.Node)
+
+    # Make sure hashing works
+    d = {ccv: 1}
+    assert d[ccv] == 1
+
+    # Ensure adaptive sampling is working as intended
+    samples = ccv.sample(1000)
+    assert len(samples) == 3
+    assert isinstance(samples[0][0], float)  # weight
+    assert isinstance(samples[0][1], float)  # value
+
+    # Ensure subset sampling is working as intended
+    subset_samples = ccv.sample(1000, subset=["a", "b"])
+    assert len(subset_samples) == 2
+
+    # Ensure forced sampling is working as intended
+    forced_samples = ccv.sample(1000, force_sample=True)
+    assert len(forced_samples) == 1000
+
+
+def test_uniform_categorical_context_variable():
+    """Test UniformCategoricalContextVariable initialization and behavior."""
+    # Make sure the construct raises if the values are empty
+    with pytest.raises(ValueError):
+        _ = context.UniformCategoricalContextVariable("ucv", [])
+
+    # Create a proper variable
+    ucv = context.UniformCategoricalContextVariable("ucv", ["a", "b", "c"])
+
+    # Make sure the support size is correct
+    assert ucv.support_size() == 3
+
+    # Make sure equality comparison returns a geometry.Tensor
+    comparison = ucv == "a"
+    assert isinstance(comparison.node, graph.Node)
+
+    # Make sure hashing works
+    d = {ucv: 1}
+    assert d[ucv] == 1
+
+    # Make sure adaptive sampling is working as intended
+    samples = ucv.sample(3)
+    assert len(samples) == 3
+    assert isinstance(samples[0][0], float)  # weight
+    assert isinstance(samples[0][1], float)  # value
+
+    # Check sampling with subset
+    subset_samples = ucv.sample(1, subset=["a", "b"])
+    assert len(subset_samples) == 1
+
+    # Test forced sampling
+    forced_samples = ucv.sample(2, force_sample=True)
+    assert len(forced_samples) == 2

--- a/tests/dtlang/test_ensemble.py
+++ b/tests/dtlang/test_ensemble.py
@@ -1,0 +1,22 @@
+"""Tests for the yakof.dtlang.ensemble module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from yakof.dtlang import context
+
+
+def test_ensemble_types():
+    """Test the ensemble type definitions."""
+    from yakof.dtlang import ensemble
+
+    # Test Weight type
+    weight: ensemble.Weight = 0.5
+    assert isinstance(weight, float)
+
+    # Test Variables type with a simple example
+    cv = context.UniformCategoricalContextVariable("test", ["a", "b"])
+    variables: ensemble.Variables = {cv: 1.0}
+    assert len(variables) == 1
+    assert cv in variables
+    assert variables[cv] == 1.0

--- a/tests/dtlang/test_geometry.py
+++ b/tests/dtlang/test_geometry.py
@@ -1,0 +1,32 @@
+"""Tests for the yakof.dtlang.geometry module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yakof.dtlang import geometry
+from yakof.frontend import graph
+
+
+def test_tensor_space():
+    """Test the tensor space initialization and basic operations."""
+    # Check that space is initialized correctly
+    assert geometry.space is not None
+
+    # Test basic tensor operations
+    a = geometry.space.placeholder("a")
+    b = geometry.space.placeholder("b")
+
+    # Addition
+    c = a + b
+    assert isinstance(c.node, graph.Node)
+
+    # Multiplication
+    d = a * b
+    assert isinstance(d.node, graph.Node)
+
+    # Constants
+    e = geometry.space.constant(5)
+    assert isinstance(e.node, graph.Node)
+
+    # Comparison
+    f = geometry.space.less(a, b)
+    assert isinstance(f.node, graph.Node)

--- a/tests/dtlang/test_index.py
+++ b/tests/dtlang/test_index.py
@@ -1,0 +1,46 @@
+"""Tests for the yakof.dtlang.index module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yakof.dtlang import index
+
+from scipy import stats
+
+import numpy as np
+
+
+def test_index_with_scalar():
+    """Make sure an index initialized with a scalar works as intended."""
+
+    idx = index.Index("idx", 0)
+    assert idx.name == "idx"
+
+    values = idx.distribution.rvs(100)
+    assert isinstance(values, np.ndarray)
+    assert values == 0
+
+
+def test_index_with_distribution():
+    """Make sure an index initialized with a distribution works as intended."""
+
+    idx = index.Index("idx", stats.uniform())
+    assert idx.name == "idx"
+
+    values = idx.distribution.rvs(100)
+    assert len(values) == 100
+    assert all(0 <= v <= 1 for v in values)
+
+
+def test_index_with_custom_distribution():
+    """Test Index with a custom distribution class."""
+
+    class CustomDistribution:
+        def rvs(self, size=1):
+            return np.ones(size) * 42
+
+    custom_dist = CustomDistribution()
+    idx = index.Index("custom", custom_dist)
+
+    values = idx.distribution.rvs(10)
+    assert len(values) == 10
+    assert all(v == 42 for v in values)

--- a/tests/dtlang/test_model.py
+++ b/tests/dtlang/test_model.py
@@ -192,15 +192,11 @@ def test_model_with_more_than_two_presence_variables():
         pvs=[x, y, z],  # Three presence variables
         indexes=[idx],
         capacities=[],
-        constraints=[constraint]
+        constraints=[constraint],
     )
 
     # Set up grid
-    grid = {
-        x: np.array([1, 2, 3]),
-        y: np.array([4, 5, 6]),
-        z: np.array([7, 8, 9])
-    }
+    grid = {x: np.array([1, 2, 3]), y: np.array([4, 5, 6]), z: np.array([7, 8, 9])}
 
     ensemble = Ensemble(model, {weekday: ["monday"]})  # type: ignore
 

--- a/tests/dtlang/test_model.py
+++ b/tests/dtlang/test_model.py
@@ -1,0 +1,209 @@
+"""Tests for the yakof.dtlang.model module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from dt_model import Ensemble
+
+from yakof.dtlang import (
+    Constraint,
+    Index,
+    Model,
+    Piecewise,
+    PresenceVariable,
+    UniformCategoricalContextVariable,
+)
+
+from scipy import stats
+
+import numpy as np
+import pytest
+
+
+def test_model_evaluation_simple():
+    """Evaluate the model is a relatively simple scenario and make
+    sure the results we get are in line with the equivalent
+    model as defined using the dt-model package."""
+
+    # === Context Variables ===
+    days = ["monday"]
+    weekday = UniformCategoricalContextVariable("weekday", days)
+
+    # === Presence Variables ===
+    drink_customers = PresenceVariable(
+        name="drink_customers",
+        cvs=[weekday],
+    )
+    food_customers = PresenceVariable(
+        "food_customers",
+        cvs=[weekday],
+    )
+
+    # === Capacity Indexes ===
+    seat_capacity = Index("seat_capacity", 10)
+
+    service_capacity = Index("service_capacity", 20)
+
+    # === Constraints ===
+    seat_constraint = Constraint(
+        usage=food_customers,
+        capacity=seat_capacity,
+        name="seat_constraint",
+    )
+    service_constraint = Constraint(
+        usage=drink_customers + food_customers,
+        capacity=service_capacity,
+        name="service_constraint",
+    )
+
+    # === Model ===
+    model = Model(
+        name="restaurant",
+        cvs=[weekday],
+        pvs=[
+            drink_customers,
+            food_customers,
+        ],
+        indexes=[
+            seat_capacity,
+            service_capacity,
+        ],
+        capacities=[],
+        constraints=[seat_constraint, service_constraint],
+    )
+
+    # === Evaluation ===
+    grid = {
+        drink_customers: np.linspace(0, 40, 5),
+        food_customers: np.linspace(0, 40, 5),
+    }
+
+    ensemble = Ensemble(model, {weekday: days})  # type: ignore
+    ccache: dict[Constraint, np.ndarray] = {}
+
+    expect = np.array(
+        [
+            [1.0, 1.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+
+    rv = model.evaluate(grid, ensemble)
+    assert np.all(rv == expect)
+
+
+def test_model_initialization():
+    """Test basic model initialization."""
+    # Create minimal components
+    weekday = UniformCategoricalContextVariable("weekday", ["monday"])
+    x = PresenceVariable("x", [weekday])
+    y = PresenceVariable("y", [weekday])
+    idx = Index("idx", 10)
+
+    # Create a simple constraint
+    constraint = Constraint(x, idx, name="test_constraint")
+
+    # Create model
+    model = Model(
+        name="test_model",
+        cvs=[weekday],
+        pvs=[x, y],
+        indexes=[idx],
+        capacities=[],
+        constraints=[constraint],
+    )
+
+    # Check model properties
+    assert model.name == "test_model"
+    assert model.cvs == [weekday]
+    assert model.pvs == [x, y]
+    assert model.indexes == [idx]
+    assert len(model.constraints) == 1
+    assert model.constraints[0].name == "test_constraint"
+
+
+def test_model_with_distribution_capacity():
+    """Test model with probabilistic capacity distribution."""
+    # Create components
+    weekday = UniformCategoricalContextVariable("weekday", ["monday"])
+    x = PresenceVariable("x", [weekday])
+    y = PresenceVariable("y", [weekday])
+
+    # Create a constraint with distribution capacity
+    normal_dist = stats.norm(loc=10, scale=0.1)
+    constraint = Constraint(x, normal_dist, name="prob_constraint")
+
+    # Create model
+    model = Model(
+        name="prob_model",
+        cvs=[weekday],
+        pvs=[x, y],
+        indexes=[],
+        capacities=[],
+        constraints=[constraint],
+    )
+
+    # Set up grid and ensemble
+    grid = {x: np.array([9.0, 10.0, 11.0]), y: np.array([5.0, 10.0, 15.0])}
+
+    ensemble = Ensemble(model, {weekday: ["monday"]})  # type: ignore
+
+    # Evaluate model
+    result = model.evaluate(grid, ensemble)
+
+    # Verify shape
+    assert result.shape == (3, 3)
+
+    # Values should be probabilities from normal CDF
+    # Since normal_dist has loc=10 and scale=0.1, evaluating at 9, 10, and 11:
+    # - Values at x=9 should be close to 1.0 (1 - CDF(9) ≈ 1.0)
+    # - Values at x=10 should be exactly 0.5 (1 - CDF(10) = 0.5)
+    # - Values at x=11 should be close to 0.0 (1 - CDF(11) ≈ 0.0)
+
+    # Decreasing values across the 1st row (as x increases)
+    assert result[0, 0] - result[0, 1] > 1e-9
+    assert result[0, 1] - result[0, 2] > 1e-9
+
+    # Since all rows have same x distribution, verify first column is consistent
+    assert abs(result[0, 0] - result[1, 0]) < 1e-9
+    assert abs(result[1, 0] - result[2, 0]) < 1e-9
+
+
+def test_model_with_more_than_two_presence_variables():
+    """Test that model evaluation raises NotImplementedError when more than 2 presence variables are provided."""
+    # Create context variable
+    weekday = UniformCategoricalContextVariable("weekday", ["monday"])
+
+    # Create three presence variables
+    x = PresenceVariable("x", [weekday])
+    y = PresenceVariable("y", [weekday])
+    z = PresenceVariable("z", [weekday])
+
+    # Create a simple constraint
+    idx = Index("idx", 10)
+    constraint = Constraint(x, idx)
+
+    # Create model with three presence variables
+    model = Model(
+        name="3d_model",
+        cvs=[weekday],
+        pvs=[x, y, z],  # Three presence variables
+        indexes=[idx],
+        capacities=[],
+        constraints=[constraint]
+    )
+
+    # Set up grid
+    grid = {
+        x: np.array([1, 2, 3]),
+        y: np.array([4, 5, 6]),
+        z: np.array([7, 8, 9])
+    }
+
+    ensemble = Ensemble(model, {weekday: ["monday"]})  # type: ignore
+
+    # Should raise NotImplementedError due to 3 presence variables
+    with pytest.raises(NotImplementedError, match="This model only supports 2D grids"):
+        model.evaluate(grid, ensemble)

--- a/tests/dtlang/test_piecewise.py
+++ b/tests/dtlang/test_piecewise.py
@@ -59,9 +59,7 @@ def test_piecewise_basics():
     # Ensure the result is the expected one
     expect = np.array([2, 27, 256])
     rv = state.values[pw.node]
-    assert len(rv) == len(expect)
-    for idx in range(len(expect)):
-        assert rv[idx] == expect[idx]
+    assert np.all(rv == expect)
 
 
 def test_piecewise_with_scalars():

--- a/tests/dtlang/test_piecewise.py
+++ b/tests/dtlang/test_piecewise.py
@@ -1,0 +1,157 @@
+"""Tests for the yakof.dtlang.piecewise module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yakof.dtlang import geometry, piecewise
+from yakof.frontend import linearize
+from yakof.numpybackend import executor
+
+import numpy as np
+
+import pytest
+
+
+def test_piecewise_basics():
+    """Make sure that Piecewise works as intended."""
+
+    # Create the expressions
+    expr1 = np.array([2, 9, 16])
+    expr2 = np.array([8, 27, 64])
+    expr3 = np.array([16, 81, 256])
+
+    # Create the filters
+    filter1 = np.array([True, False, False])
+    filter2 = np.array([False, True, False])
+
+    # Create the placeholders
+    p_expr1 = geometry.space.placeholder("expr1")
+    p_expr2 = geometry.space.placeholder("expr2")
+    p_expr3 = geometry.space.placeholder("expr3")
+    p_filter1 = geometry.space.placeholder("filter1")
+    p_filter2 = geometry.space.placeholder("filter2")
+
+    # Create the resulting piecewise function
+    pw = piecewise.Piecewise(
+        (p_expr1, p_filter1),
+        (p_expr2, p_filter2),
+        (p_expr3, True),
+    )
+
+    # Linearize an execution plan out of the piecewise
+    plan = linearize.forest(pw.node)
+    assert len(plan) == 6
+
+    # Create the evaluation state
+    state = executor.State(
+        {
+            p_expr1.node: expr1,
+            p_expr2.node: expr2,
+            p_expr3.node: expr3,
+            p_filter1.node: filter1,
+            p_filter2.node: filter2,
+        }
+    )
+
+    # Actually evaluate the piecewise function
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Ensure the result is the expected one
+    expect = np.array([2, 27, 256])
+    rv = state.values[pw.node]
+    assert len(rv) == len(expect)
+    for idx in range(len(expect)):
+        assert rv[idx] == expect[idx]
+
+
+def test_piecewise_with_scalars():
+    """Test Piecewise with scalar values."""
+    # Simple case with scalar values
+    result = piecewise.Piecewise(
+        (1, geometry.space.constant(True)), (2, geometry.space.constant(False))
+    )
+
+    # Linearize
+    plan = linearize.forest(result.node)
+    state = executor.State(values={})
+
+    # Evaluate
+    for node in plan:
+        executor.evaluate(state, node)
+
+    assert state.values[result.node] == 1
+
+
+def test_piecewise_empty():
+    """Test Piecewise with no clauses raises ValueError."""
+    with pytest.raises(ValueError):
+        piecewise.Piecewise()
+
+
+def test_piecewise_filtering():
+    """Test the internal _filter_clauses function."""
+    clauses = (
+        (1, False),
+        (2, True),
+        (3, False),  # Should be filtered out
+        (4, True),  # Should be filtered out
+    )
+
+    filtered = piecewise._filter_clauses(clauses)
+    assert len(filtered) == 2
+    assert filtered[0] == (1, False)
+    assert filtered[1] == (2, True)
+
+
+def test_piecewise_with_constant_conditions():
+    """Test Piecewise functionality with constant conditions."""
+    # Create expression tensors
+    expr1 = geometry.space.placeholder("expr1")
+    expr2 = geometry.space.placeholder("expr2")
+    expr3 = geometry.space.placeholder("expr3")
+
+    # Create piecewise with constant conditions
+    pw = piecewise.Piecewise(
+        (expr1, False),       # Constant False condition
+        (expr2, True),        # Constant True condition
+        (expr3, True),        # This should be ignored as it's after a True condition
+    )
+
+    # Linearize the execution plan
+    plan = linearize.forest(pw.node)
+
+    # Set up evaluation state with tensor values
+    state = executor.State({
+        expr1.node: np.array([10, 20, 30]),
+        expr2.node: np.array([40, 50, 60]),
+        expr3.node: np.array([70, 80, 90]),
+    })
+
+    # Evaluate the piecewise function
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Since the second condition is True, the result should be expr2
+    result = state.values[pw.node]
+    expected = np.array([40, 50, 60])
+
+    assert np.array_equal(result, expected)
+
+    # Test with just default case (single True condition) and a false condition
+    # to avoid empty condition list error
+    pw_default = piecewise.Piecewise(
+        (expr2, False),     # False condition (needed to avoid empty condition list)
+        (expr1, True),      # Default case
+    )
+
+    plan_default = linearize.forest(pw_default.node)
+    state_default = executor.State({
+        expr1.node: np.array([10, 20, 30]),
+        expr2.node: np.array([40, 50, 60]),
+    })
+
+    for node in plan_default:
+        executor.evaluate(state_default, node)
+
+    result_default = state_default.values[pw_default.node]
+    assert np.array_equal(result_default, np.array([10, 20, 30]))

--- a/tests/dtlang/test_piecewise.py
+++ b/tests/dtlang/test_piecewise.py
@@ -112,20 +112,22 @@ def test_piecewise_with_constant_conditions():
 
     # Create piecewise with constant conditions
     pw = piecewise.Piecewise(
-        (expr1, False),       # Constant False condition
-        (expr2, True),        # Constant True condition
-        (expr3, True),        # This should be ignored as it's after a True condition
+        (expr1, False),  # Constant False condition
+        (expr2, True),  # Constant True condition
+        (expr3, True),  # This should be ignored as it's after a True condition
     )
 
     # Linearize the execution plan
     plan = linearize.forest(pw.node)
 
     # Set up evaluation state with tensor values
-    state = executor.State({
-        expr1.node: np.array([10, 20, 30]),
-        expr2.node: np.array([40, 50, 60]),
-        expr3.node: np.array([70, 80, 90]),
-    })
+    state = executor.State(
+        {
+            expr1.node: np.array([10, 20, 30]),
+            expr2.node: np.array([40, 50, 60]),
+            expr3.node: np.array([70, 80, 90]),
+        }
+    )
 
     # Evaluate the piecewise function
     for node in plan:
@@ -140,15 +142,17 @@ def test_piecewise_with_constant_conditions():
     # Test with just default case (single True condition) and a false condition
     # to avoid empty condition list error
     pw_default = piecewise.Piecewise(
-        (expr2, False),     # False condition (needed to avoid empty condition list)
-        (expr1, True),      # Default case
+        (expr2, False),  # False condition (needed to avoid empty condition list)
+        (expr1, True),  # Default case
     )
 
     plan_default = linearize.forest(pw_default.node)
-    state_default = executor.State({
-        expr1.node: np.array([10, 20, 30]),
-        expr2.node: np.array([40, 50, 60]),
-    })
+    state_default = executor.State(
+        {
+            expr1.node: np.array([10, 20, 30]),
+            expr2.node: np.array([40, 50, 60]),
+        }
+    )
 
     for node in plan_default:
         executor.evaluate(state_default, node)

--- a/tests/dtlang/test_presence.py
+++ b/tests/dtlang/test_presence.py
@@ -1,0 +1,22 @@
+"""Tests for the yakof.dtlang.presence module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yakof.dtlang import context, presence
+
+
+def test_presence_variable():
+    """Ensure that the PresenceVariable is working as intended."""
+
+    # Create the context variables on which we depend
+    cv1 = context.UniformCategoricalContextVariable("cv1", ["a", "b", "c"])
+    cv2 = context.UniformCategoricalContextVariable("cv1", ["a", "b", "c"])
+
+    # Create the actual presence variable
+    pv = presence.PresenceVariable("pv", [cv1, cv2])
+
+    # Make sure the name is correct
+    assert pv.name == "pv"
+
+    # Make sure the list of context variables is correct
+    assert pv.cvs == [cv1, cv2]

--- a/uv.lock
+++ b/uv.lock
@@ -280,6 +280,7 @@ source = { editable = "." }
 dependencies = [
     { name = "dt-model" },
     { name = "numpy" },
+    { name = "scipy" },
     { name = "sympy" },
 ]
 
@@ -294,6 +295,7 @@ dev = [
 requires-dist = [
     { name = "dt-model", git = "https://github.com/fbk-most/dt-model?rev=main" },
     { name = "numpy" },
+    { name = "scipy" },
     { name = "sympy" },
 ]
 

--- a/yakof/dtlang/__init__.py
+++ b/yakof/dtlang/__init__.py
@@ -1,0 +1,41 @@
+"""
+Digital Twins Language (dtlang)
+===============================
+
+This package provides a domain-specific language for creating and evaluating
+digital twins sustainability models. It integrates concepts from:
+
+- Tensor computations in a 3D XYZ space
+- Context variables representing uncertainty
+- Presence variables defining spatial dimensions
+- Constraints between resource usage and capacity
+- Ensemble-based evaluation to account for uncertainty
+
+The package allows for definition and evaluation of sustainability models
+that can assess environmental constraints across spatial grids while
+incorporating both deterministic and probabilistic elements.
+
+Key components:
+- Model: The main container for all model elements
+- Constraint: Relates resource usage to capacity
+- PresenceVariable: Defines spatial dimensions
+- ContextVariable: Represents sources of uncertainty
+- Index: Parameters that may be constant or sampled from distributions
+- Piecewise: Support for conditional expressions in models
+"""
+
+from .constraint import Constraint
+from .context import UniformCategoricalContextVariable
+from .index import Index
+from .model import Model
+from .piecewise import Piecewise
+from .presence import PresenceVariable
+
+__all__ = [
+    "Constraint",
+    "Index",
+    "Model",
+    "Piecewise",
+    "PresenceVariable",
+    "UniformCategoricalContextVariable",
+]

--- a/yakof/dtlang/constraint.py
+++ b/yakof/dtlang/constraint.py
@@ -1,0 +1,52 @@
+"""
+Constraints
+===========
+
+This module defines constraint types used in the digital twins model
+framework. Constraints represent relationships between resource usage and
+available capacity, forming the core of the sustainability assessment.
+
+Constraints can work with both deterministic capacities (represented as
+tensors) and probabilistic capacities (represented by cumulative distribution
+functions). When evaluated, constraints determine whether resource usage
+remains within acceptable bounds relative to capacity.
+"""
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+
+from . import geometry
+
+
+@runtime_checkable
+class CumulativeDistribution(Protocol):
+    """Protocol matching scipy.stats distributions interface"""
+
+    def cdf(self, x: float | np.ndarray, *args, **kwds) -> float | np.ndarray: ...
+
+
+class Constraint:
+    """Represents a constraint between resource usage and capacity.
+
+    A constraint associates a resource usage tensor with a capacity, which can be
+    either a fixed tensor or a probabilistic distribution. When evaluated, the
+    constraint indicates whether the usage is within acceptable bounds relative
+    to the capacity.
+
+    Args:
+        usage: A tensor representing resource consumption
+        capacity: Either a tensor or a distribution representing available capacity
+        name: Optional constraint name
+    """
+
+    def __init__(
+        self,
+        usage: geometry.Tensor,
+        capacity: geometry.Tensor | CumulativeDistribution,
+        name: str = "",
+    ) -> None:
+        self.usage = usage
+        self.capacity = capacity
+        self.name = name

--- a/yakof/dtlang/context.py
+++ b/yakof/dtlang/context.py
@@ -3,7 +3,7 @@ Context Variables
 =================
 
 This module implements context variables (i.e., variables associated
-with uncertainty) to graph.placeholder tensors in the XYZ space.
+with uncertainty) as graph.placeholder tensors in the XYZ space.
 
 Two kind of context variables are supported:
 

--- a/yakof/dtlang/context.py
+++ b/yakof/dtlang/context.py
@@ -1,0 +1,169 @@
+"""
+Context Variables
+=================
+
+This module implements context variables (i.e., variables associated
+with uncertainty) to graph.placeholder tensors in the XYZ space.
+
+Two kind of context variables are supported:
+
+1. categorical, where the variable assumes a discrete set of values
+each associated with a given probability;
+
+2. continuous, where the variable assumes a continuous range of values.
+
+This implementation uses the original `dt-model` ensemble, thus, in
+addition, we also need compatibility types to interact with it.
+
+We compile both kind of context variables to graph.placeholder tensors
+using, as for other types in this package, the XYZ space.
+"""
+
+from typing import Mapping, Protocol, Sequence, runtime_checkable
+
+import numpy as np
+import random
+
+from . import geometry
+
+from ..frontend import autoenum, graph
+
+
+SampleWeight = float
+"""The weight of a value sampled from an EnsembleSampler."""
+
+SampleValue = float
+"""SampledValue is the value sampled from an EnsembleSampler."""
+
+
+@runtime_checkable
+class EnsembleSampler(Protocol):
+    """A protocol that generalizes over categorical and continuous distributions
+    to provide a unified interface for sampling.
+
+    Methods:
+        support_size: Returns the size of the support of the distribution.
+        sample: Samples weighted values from the distribution.
+    """
+
+    def support_size(self) -> int | None: ...
+
+    def sample(
+        self,
+        nr: int = 1,
+        *,
+        subset: Sequence[str] | None = None,
+        force_sample: bool = False,
+    ) -> list[tuple[SampleWeight, SampleValue]]: ...
+
+
+class CategoricalContextVariable(geometry.Tensor):
+    """A context variable that can take on categorical values with
+    associated probabilities.
+
+    This class represents a categorical random variable that can be used
+    in tensor computations.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        values: Mapping[str, float],
+    ) -> None:
+        """Initialize a categorical context variable.
+
+        Args:
+            name: The name of the context variable.
+            values: A mapping from value names to their probabilities.
+        """
+
+        # 1. Ensure that we have at least one value in this context variable
+        if len(values) <= 0:
+            raise ValueError("values must be a non-empty sequence")
+
+        # 2. Create the enumeration type and save the associated tensor
+        self.__enum = autoenum.Type(geometry.space, name)
+        super().__init__(geometry.space, self.__enum.tensor.node)
+
+        # 3. Save the cateorial values and their probability
+        self.__values = values
+
+        # 4. Generate and save the enumeration IDs for each value
+        self.__mapping = {v: autoenum.Value(self.__enum, v) for v in self.__values}
+
+    # Redefine the lazy equality to allow for comparison with the original strings
+    def __eq__(self, value: str) -> geometry.Tensor:  # type: ignore
+        return geometry.space.equal(self.__enum.tensor, self.__mapping[value].tensor)
+
+    # Redefine the identity hashing since we have redefined the equality
+    def __hash__(self) -> int:
+        return id(self)
+
+    def support_size(self) -> int:
+        """Returns the number of possible values in this categorical variable."""
+        return len(self.__values)
+
+    def sample(
+        self,
+        nr: int = 1,
+        *,
+        subset: Sequence[str] | None = None,
+        force_sample: bool = False,
+    ) -> list[tuple[SampleWeight, SampleValue]]:
+        """Sample values from this categorical distribution.
+
+        Args:
+            nr: Number of samples to draw.
+            subset: Optional subset of values to sample from.
+            force_sample: Whether to force sampling even if nr >= support_size.
+
+        Returns:
+            A list of (probability, value) tuples.
+        """
+        # TODO: subset (if defined) should be a subset of the support (also: with repetitions?)
+
+        keys, size = list(self.__values.keys()), self.support_size()
+        if subset is not None:
+            keys, size = subset, len(subset)
+
+        if force_sample or nr < size:
+            ratio = 1 / nr
+            keys = random.choices(keys, k=nr)
+        else:
+            ratio = 1 / size
+
+        return [(ratio, float(self.__mapping[k].value)) for k in keys]
+
+
+# Ensure that the CategoricalContextVariable type implements EnsembleSampler
+_: EnsembleSampler = CategoricalContextVariable("", {"a": 0.5, "b": 0.5})
+
+
+class UniformCategoricalContextVariable(CategoricalContextVariable):
+    """A categorical context variable where all values have equal probability."""
+
+    def __init__(
+        self,
+        name: str,
+        values: Sequence[str],
+    ) -> None:
+        """Initialize a uniform categorical context variable.
+
+        Args:
+            name: The name of the context variable.
+            values: A sequence of possible values, all with equal probability.
+        """
+        # 1. Ensure that we have at least one value in this context variable
+        if len(values) <= 0:
+            raise ValueError("values must be a non-empty sequence")
+
+        # 2. Defer to the parent class constructor
+        super().__init__(name, {v: 1 / len(values) for v in values})
+
+
+# Ensure that the UniformCategoricalContextVariable type implements EnsembleSampler
+_: EnsembleSampler = UniformCategoricalContextVariable("", ["a", "b"])
+
+
+ContextVariable = UniformCategoricalContextVariable | CategoricalContextVariable
+"""A context variable is one of the many possible context variable types."""

--- a/yakof/dtlang/context.py
+++ b/yakof/dtlang/context.py
@@ -91,6 +91,10 @@ class CategoricalContextVariable(geometry.Tensor):
         # 4. Generate and save the enumeration IDs for each value
         self.__mapping = {v: autoenum.Value(self.__enum, v) for v in self.__values}
 
+    # TODO(bassosimone): consider also adding support for inequality. FWIW, I am much
+    # more torn in terms of implementing `<` since, in principle, there is no strong
+    # guarantee that the support of enumerations will be totally ordered.
+
     # Redefine the lazy equality to allow for comparison with the original strings
     def __eq__(self, value: str) -> geometry.Tensor:  # type: ignore
         return geometry.space.equal(self.__enum.tensor, self.__mapping[value].tensor)
@@ -113,8 +117,8 @@ class CategoricalContextVariable(geometry.Tensor):
         """Sample values from this categorical distribution.
 
         Args:
-            nr: Number of samples to draw.
-            subset: Optional subset of values to sample from.
+            nr: Upper bound for the number of samples to draw.
+            subset: Optional subset of values to draw from.
             force_sample: Whether to force sampling even if nr >= support_size.
 
         Returns:
@@ -122,16 +126,22 @@ class CategoricalContextVariable(geometry.Tensor):
         """
         # TODO: subset (if defined) should be a subset of the support (also: with repetitions?)
 
+        # 1. Use either the whole support or a subset thereof
         keys, size = list(self.__values.keys()), self.support_size()
         if subset is not None:
             keys, size = subset, len(subset)
 
+        # 2. Honour the request to sample and return the whole support
+        # where reasonable, to get a better coverage.
         if force_sample or nr < size:
             ratio = 1 / nr
+            # TODO(bassosimone): this line is wrong and we would need to
+            # also include the weights into sampling
             keys = random.choices(keys, k=nr)
         else:
             ratio = 1 / size
 
+        # 3. Actually generate the ensemble input
         return [(ratio, float(self.__mapping[k].value)) for k in keys]
 
 

--- a/yakof/dtlang/ensemble.py
+++ b/yakof/dtlang/ensemble.py
@@ -1,0 +1,19 @@
+"""
+Ensemble
+========
+
+Defines the types used by the `dt-model` ensemble package.
+"""
+
+from typing import Iterator
+
+from .context import ContextVariable
+
+Weight = float
+"""The weight of an ensemble element."""
+
+Variables = dict[ContextVariable, float]
+"""Maps context variables to their values in the ensemble."""
+
+Iter = Iterator[tuple[Weight, Variables]]
+"""Iterator over the elements of the ensemble space."""

--- a/yakof/dtlang/geometry.py
+++ b/yakof/dtlang/geometry.py
@@ -1,0 +1,16 @@
+"""
+Model Geometry
+==============
+
+This module defines the model geometry in which we operate. We use a 3d
+space where the first two dimensions are presence variables and the third
+dimension contains the ensemble space.
+"""
+
+from ..frontend import abstract, bases
+
+space = abstract.TensorSpace(bases.XYZ())
+"""Computation space instance."""
+
+Tensor = abstract.Tensor[bases.XYZ]
+"""Computation tensor type."""

--- a/yakof/dtlang/index.py
+++ b/yakof/dtlang/index.py
@@ -1,0 +1,65 @@
+"""
+Index Implementation
+====================
+
+This module implements the `Index` type, which represents either a constant
+value or a placeholder for sampling from a random distribution. In either case,
+we compile the Indes into a graph.placeholder tensor in the XYZ space.
+"""
+
+from typing import Protocol, cast, runtime_checkable
+
+import numpy as np
+
+from ..frontend import graph
+
+from . import geometry
+
+
+@runtime_checkable
+class Distribution(Protocol):
+    """Protocol representing the distribution from which to sample the
+    index value inside the ensemble space.
+
+    Methods:
+        rvs: Sample random variates from the distribution.
+    """
+
+    def rvs(self, size: int = 1) -> np.ndarray: ...
+
+
+class _Constant:
+    """Fake Distribution that just returns a constant value."""
+
+    def __init__(self, value: graph.Scalar) -> None:
+        self.value = value
+
+    def rvs(self, size: int = 1) -> np.ndarray:
+        return np.asarray(self.value)
+
+
+# Make sure that the _Constant type implements Distribution
+_: Distribution = _Constant(0)
+
+
+class Index(geometry.Tensor):
+    """The Index is a geometry tensor representing either a constant value
+    or a placeholder for sampling from a random distribution. In either case,
+    the evaluator will need to use the `distribution` attribute to get the
+    initial placeholder value through sampling.
+
+    Args:
+        name: The name of the index.
+        value: The initial value of the index, which can be a constant or a
+            distribution from which to sample in the ensemble space.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        value: graph.Scalar | Distribution,
+    ) -> None:
+        if isinstance(value, graph.Scalar):
+            value = _Constant(value)
+        super().__init__(geometry.space, graph.placeholder(name))
+        self.distribution = cast(Distribution, value)

--- a/yakof/dtlang/index.py
+++ b/yakof/dtlang/index.py
@@ -4,7 +4,7 @@ Index Implementation
 
 This module implements the `Index` type, which represents either a constant
 value or a placeholder for sampling from a random distribution. In either case,
-we compile the Indes into a graph.placeholder tensor in the XYZ space.
+we compile the Index into a graph.placeholder tensor in the XYZ space.
 """
 
 from typing import Protocol, cast, runtime_checkable

--- a/yakof/dtlang/model.py
+++ b/yakof/dtlang/model.py
@@ -66,6 +66,10 @@ class Model:
         Returns:
             A numpy array representing the constraint satisfaction field
         """
+        # TODO(bassosimone): to some extent, this could also be a method of
+        # the actual Constraint class, since the distribution already specifies
+        # we're operating in the numpy domain. The same argument could
+        # potentially hold for the evaluation of the indexes.
         usage = cache[constr.usage.node]
         if isinstance(constr.capacity, CumulativeDistribution):
             return np.asarray(1.0) - constr.capacity.cdf(usage)
@@ -91,6 +95,11 @@ class Model:
         Raises:
             NotImplementedError: If more than 2 presence variables are specified
         """
+        # TODO(bassosimone): the original implementation is also saving the
+        # value of each constraint, which is very useful for debugging. I am
+        # a bit torn with respect to this. For now, I have not added this
+        # because I wanted this class to be immutable. Need to think a bit more.
+
         # 1. Create empty state with empty bindings
         cache: dict[graph.Node, np.ndarray] = {}
 
@@ -129,6 +138,9 @@ class Model:
         # 5. Create placeholders for the indexes
         for index in self.indexes:
             if isinstance(index, Index):
+                # TODO(bassosimone): keep in mind that random variates sampling
+                # here is partially incorrect, because we're not extending the
+                # ensemble space and draw "enough" samples from the distribution.
                 value = index.distribution.rvs(size=ensemble_size)
                 value = np.expand_dims(value, axis=(0, 1))  # x, y, Z
                 cache[index.node] = value

--- a/yakof/dtlang/model.py
+++ b/yakof/dtlang/model.py
@@ -1,0 +1,158 @@
+"""
+Model Definition
+================
+
+This module defines the core Model class which represents a digital twins
+sustainability assessment framework. The Model combines presence variables,
+context variables, indices, capacities and constraints into an evaluable model
+that can assess environmental constraints across a spatial grid while
+incorporating uncertainty via ensemble methods.
+"""
+
+from typing import Sequence, cast
+
+import numpy as np
+
+from . import ensemble
+
+from .constraint import Constraint, CumulativeDistribution
+from .context import ContextVariable
+from .geometry import Tensor
+from .index import Index
+from .presence import PresenceVariable
+
+from ..frontend import graph, linearize
+from ..numpybackend import executor
+
+
+class Model:
+    def __init__(
+        self,
+        name,
+        cvs: Sequence[ContextVariable],
+        pvs: Sequence[PresenceVariable],
+        indexes: Sequence[Tensor],
+        capacities: Sequence[Tensor],
+        constraints: Sequence[Constraint],
+    ) -> None:
+        """Initialize the digital-twins model.
+
+        Args:
+            name: The name of the model
+            cvs: Sequence of context variables representing uncertainty dimensions
+            pvs: Sequence of presence variables defining the spatial grid
+            indexes: Sequence of index tensors
+            capacities: Sequence of capacity tensors
+            constraints: Sequence of constraints to be evaluated
+        """
+        self.name = name
+        self.cvs = cvs
+        self.pvs = pvs
+        self.indexes = indexes
+        self.capacities = capacities
+        self.constraints = constraints
+
+    def __evaluate_constraint(
+        self,
+        constr: Constraint,
+        cache: dict[graph.Node, np.ndarray],
+    ) -> np.ndarray:
+        """Evaluate a single constraint with the provided cache.
+
+        Args:
+            constr: The constraint to evaluate
+            cache: Dictionary mapping nodes to their evaluated values
+
+        Returns:
+            A numpy array representing the constraint satisfaction field
+        """
+        usage = cache[constr.usage.node]
+        if isinstance(constr.capacity, CumulativeDistribution):
+            return np.asarray(1.0) - constr.capacity.cdf(usage)
+        return usage <= cache[constr.capacity.node]
+
+    def evaluate(
+        self,
+        grid: dict[PresenceVariable, np.ndarray],
+        ensemble: ensemble.Iter,
+    ) -> np.ndarray:
+        """Evaluate the model over a grid and ensemble of scenarios.
+
+        Produces a sustainability field that aggregates the constraint
+        satisfaction across the ensemble of parameter settings.
+
+        Args:
+            grid: Dictionary mapping presence variables to grid coordinate arrays
+            ensemble: Iterator over weighted ensemble scenarios
+
+        Returns:
+            A 2D numpy array representing the sustainability field
+
+        Raises:
+            NotImplementedError: If more than 2 presence variables are specified
+        """
+        # 1. Create empty state with empty bindings
+        cache: dict[graph.Node, np.ndarray] = {}
+
+        # 2. Fill the placeholders for the presence variables
+        if len(self.pvs) != 2:
+            raise NotImplementedError("This model only supports 2D grids")
+
+        cache[self.pvs[0].node] = cast(
+            np.ndarray,
+            np.expand_dims(grid[self.pvs[0]], axis=(0, 2)),  # x, Y, z
+        )
+
+        cache[self.pvs[1].node] = cast(
+            np.ndarray, np.expand_dims(grid[self.pvs[1]], axis=(1, 2))  # X, y, z
+        )
+
+        x_size = grid[self.pvs[0]].shape[0]
+        y_size = grid[self.pvs[1]].shape[0]
+
+        # 3. Create Z-aligned tensors for the ensemble weights
+        weights = np.array([c[0] for c in ensemble])
+        weights = np.expand_dims(weights, axis=(0, 1))  # x, y, Z
+        ensemble_size = weights.shape[2]
+
+        # 4. Create Z-aligned placeholders for the ensemble values
+        collector: dict[ContextVariable, list[float]] = {}
+        for _, entry in ensemble:
+            for cv, value in entry.items():
+                collector.setdefault(cv, []).append(value)
+
+        for key, values in collector.items():
+            values = np.asarray(values)
+            values = np.expand_dims(values, axis=(0, 1))  # x, y, Z
+            cache[key.node] = values
+
+        # 5. Create placeholders for the indexes
+        for index in self.indexes:
+            if isinstance(index, Index):
+                value = index.distribution.rvs(size=ensemble_size)
+                value = np.expand_dims(value, axis=(0, 1))  # x, y, Z
+                cache[index.node] = value
+
+        # 6. Build the list of graph nodes to evaluate
+        allnodes: list[graph.Node] = []
+        for constr in self.constraints:
+            allnodes.append(constr.usage.node)
+            if not isinstance(constr.capacity, CumulativeDistribution):
+                allnodes.append(constr.capacity.node)
+
+        # 7. Sort and evaluate the graph in topological order
+        allnodes = linearize.forest(*allnodes)
+        state = executor.State(values=cache, flags=graph.NODE_FLAG_TRACE)
+        for node in allnodes:
+            executor.evaluate(state, node)
+
+        # 8. Compute the sustainability field based on the results
+        field = np.ones((x_size, y_size, ensemble_size))
+        for constr in self.constraints:
+            field *= self.__evaluate_constraint(constr, cache)
+
+        # 9. Apply the ensemble weights to the field
+        field *= weights
+
+        # 10. project the constraints over X, Y space by summing over Z
+        return np.sum(field, axis=2)

--- a/yakof/dtlang/piecewise.py
+++ b/yakof/dtlang/piecewise.py
@@ -22,7 +22,7 @@ Clause = tuple[Expr, Cond]
 
 
 def Piecewise(*clauses: Clause) -> geometry.Tensor:
-    """Converts the provide clauses arranged according to the sympy.Piecewise
+    """Converts the provided clauses arranged according to the sympy.Piecewise
     convention into a graph.multi_clause_where computation tensor in XYZ.
 
     Args:
@@ -34,7 +34,6 @@ def Piecewise(*clauses: Clause) -> geometry.Tensor:
     Raises:
         ValueError: If no clauses are provided.
     """
-    # Ensure that we remove all the clauses after a true clause
     return _to_tensor(_filter_clauses(clauses))
 
 

--- a/yakof/dtlang/piecewise.py
+++ b/yakof/dtlang/piecewise.py
@@ -1,0 +1,83 @@
+"""
+Piecewise Emulation
+===================
+
+This module emulates sympy.Piecewise using the tensor language frontend, by mapping
+a Piecewise invocation to a graph.multi_clause_where tensor in the XYZ space.
+"""
+
+from ..frontend import graph
+
+from . import geometry
+
+
+Cond = geometry.Tensor | graph.Scalar
+"""Condition for a piecewise clause."""
+
+Expr = geometry.Tensor | graph.Scalar
+"""Expression for a piecewise clause."""
+
+Clause = tuple[Expr, Cond]
+"""Clause provided to piecewise."""
+
+
+def Piecewise(*clauses: Clause) -> geometry.Tensor:
+    """Converts the provide clauses arranged according to the sympy.Piecewise
+    convention into a graph.multi_clause_where computation tensor in XYZ.
+
+    Args:
+        *clauses: The clauses to be converted.
+
+    Returns:
+        The computation tensor representing the piecewise function.
+
+    Raises:
+        ValueError: If no clauses are provided.
+    """
+    # Ensure that we remove all the clauses after a true clause
+    return _to_tensor(_filter_clauses(clauses))
+
+
+def _filter_clauses(clauses: tuple[Clause, ...]) -> list[Clause]:
+    """This function removes the clauses after the first true clause, to
+    correctly emulate the sumpy.Piecewise behaviour.
+
+    Args:
+        clauses: The clauses to be filtered.
+
+    Returns:
+        The filtered clauses.
+    """
+    filtered: list[Clause] = []
+    for expr, cond in clauses:
+        filtered.append((expr, cond))
+        if cond is True:
+            break
+    return filtered
+
+
+def _to_tensor(clauses: list[Clause]) -> geometry.Tensor:
+    # 1. Bail if there are no remaining clauses
+    if len(clauses) < 1:
+        raise ValueError("piecewise: at least one clause is required")
+
+    # 2. Check whether there is a default case and otherwise use NaN
+    default_value: Expr = float("NaN")
+    last_clause = clauses[-1]
+    if last_clause[1] is True:
+        default_value = last_clause[0]
+        clauses = clauses[:-1]
+    if isinstance(default_value, graph.Scalar):
+        default_value = geometry.space.constant(default_value)
+
+    # 3. Prepare the reversed clauses adapting the types
+    reversed: list[tuple[geometry.Tensor, geometry.Tensor]] = []
+    for expr, cond in clauses:
+        if isinstance(expr, graph.Scalar):
+            expr = geometry.space.constant(expr)
+        if isinstance(cond, graph.Scalar):
+            cond = geometry.space.constant(cond)
+        reversed.append((cond, expr))
+
+    # 4. We're now all set call multi_clause_where
+    return geometry.space.multi_clause_where(reversed, default_value)

--- a/yakof/dtlang/presence.py
+++ b/yakof/dtlang/presence.py
@@ -1,0 +1,35 @@
+"""
+Presence Variables
+==================
+
+This module defines presence variables which represent the spatial dimensions
+in the model's grid. These variables are used to create the coordinate system
+within which sustainability assessments are performed.
+
+Presence variables can depend on context variables, allowing the spatial
+dimensions to be influenced by uncertainty factors.
+"""
+
+from typing import Sequence
+
+from ..frontend import graph
+
+from . import geometry
+from .context import ContextVariable
+
+
+class PresenceVariable(geometry.Tensor):
+    """Represents a spatial dimension in the sustainability grid.
+
+    A presence variable defines one axis of the spatial grid used for
+    sustainability assessment. It can depend on context variables,
+    allowing the spatial dimension to be influenced by uncertainty.
+
+    Args:
+        name: The name of the presence variable
+        cvs_deps: Sequence of context variables that this presence variable depends on
+    """
+
+    def __init__(self, name: str, cvs: Sequence[ContextVariable]) -> None:
+        super().__init__(geometry.space, graph.placeholder(name))
+        self.cvs = cvs


### PR DESCRIPTION
This diff adds a modified version of most (no pun intended) of the dt_model that allows us to evaluate models using a codebase that is as similar as possible to the actual dt_model.

The only aspect of dt_model that remains as a dependency is the "scheduler" component of the architecture, i.e., the one that ensures we're properly creating ensembles.

In general, this code is not meant to be merged upstream into the dt_model, rather its function is to aid us in A/B testing.ble

At the moment in which we're merging this code, there are some question marks, open problems and TODOs to deal with. In any  case, I feel like the time is ripe for merging and to move forward to more aggressive A/B testing. We'll therefore deal with the issues at a later time, using the existing TODO comments as an atlas to know what needs fixes.