### PR TITLE
feat(abtesting): start A/B testing with dt_model

### DIFF
--- a/tests/abtesting/__init__.py
+++ b/tests/abtesting/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the yakof.abtesting package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/abtesting/test_model5.py
+++ b/tests/abtesting/test_model5.py
@@ -1,0 +1,20 @@
+"""Tests for the yakof.abtesting.model5 package."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yakof.abtesting.model5 import a, b
+
+import numpy as np
+
+
+def test_abtesting():
+    # TODO(bassosimone): force using the same random seed
+
+    # Run using the original dt_model implementation
+    rv_a = a.run()
+
+    # Run using the yakof based implementation
+    rv_b = b.run()
+
+    # Ensure the result is the same
+    assert np.allclose(rv_a, rv_b)

--- a/yakof/abtesting/__init__.py
+++ b/yakof/abtesting/__init__.py
@@ -1,0 +1,7 @@
+"""
+A/B Testing
+===========
+
+This package contains code to A/B test the yakof based
+dt_model subset and the original dt_model.
+"""

--- a/yakof/abtesting/model5/__init__.py
+++ b/yakof/abtesting/model5/__init__.py
@@ -1,0 +1,7 @@
+"""
+Model 5
+=======
+
+This package contains the fifth model written by Maryam. See
+https://github.com/maryamsajedi/coffee_dt/blob/master/coffee_dt_5.py
+"""

--- a/yakof/abtesting/model5/a.py
+++ b/yakof/abtesting/model5/a.py
@@ -1,0 +1,106 @@
+"""
+A in the A/B testing
+====================
+
+This module contains the original implementation of model5, with minor
+changes required to adapt it for A/B testing.
+
+See https://github.com/maryamsajedi/coffee_dt/blob/master/coffee_dt_5.py.
+"""
+
+from dt_model import (
+    UniformCategoricalContextVariable,
+    PresenceVariable,
+    Constraint,
+    Ensemble,
+    Model,
+    Index,
+)
+from scipy.stats import triang
+
+import numpy as np
+from sympy import Symbol
+
+
+def run() -> np.ndarray:
+    """Runs the model and returns its result."""
+
+    # === Context Variables ===
+    days = [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ]
+    CV_weekday = UniformCategoricalContextVariable("weekday", [Symbol(v) for v in days])
+
+    # === Presence Variables ===
+    drink_customers = PresenceVariable(
+        name="drink_customers",
+        cvs=[],
+    )
+    food_customers = PresenceVariable(
+        "food_customers",
+        cvs=[],
+    )
+
+    seat_capacity = Index("seat_capacity", 50)
+    # Most common service capacity is 100, ranging from 60 to 100
+    service_capacity = Index("service_capacity", triang(loc=80.0, scale=40.0, c=0.5))
+
+    # Usage of drink customers from the seats available in the bar
+    U_drink_seat = Index("drink customers seat usage factor", 0.2)
+
+    # Usage of food customers from the seats available in the bar
+    U_food_seat = Index("food customers seat usage factor", 0.8)
+
+    # Usage of drink customers from the service
+    U_service_drink = Index("drink customers service usage factor", 0.4)
+
+    # Usage of food customers from the service
+    U_service_food = Index("food customers service usage factor", 0.9)
+
+    # === Constraints ===
+    seat_constraint = Constraint(
+        usage=drink_customers * U_drink_seat + food_customers * U_food_seat,  # type: ignore
+        capacity=seat_capacity,
+    )
+
+    service_constraint = Constraint(
+        usage=food_customers * U_service_food + drink_customers * U_service_drink,  # type: ignore
+        capacity=service_capacity,
+    )
+
+    # === Model ===
+    model = Model(
+        "coffee_shop",
+        cvs=[CV_weekday],
+        pvs=[drink_customers, food_customers],
+        indexes=[
+            seat_capacity,
+            U_drink_seat,
+            U_food_seat,
+            U_service_drink,
+            U_service_food,
+            service_capacity,
+        ],
+        constraints=[seat_constraint, service_constraint],
+        capacities=[seat_capacity, service_capacity],
+    )
+
+    # === Evaluation ===
+    ensemble = Ensemble(model, {CV_weekday: days}, cv_ensemble_size=7)
+
+    grid = {
+        drink_customers: np.linspace(0, 100, 11),
+        food_customers: np.linspace(0, 100, 11),
+    }
+
+    return model.evaluate(grid, ensemble)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/yakof/abtesting/model5/b.py
+++ b/yakof/abtesting/model5/b.py
@@ -1,0 +1,104 @@
+"""
+B in the A/B testing
+====================
+
+This module contains the yakof-based implementation of model5, with minor
+changes from the original, required to use yakof.
+"""
+
+from dt_model import Ensemble
+from yakof.dtlang import (
+    UniformCategoricalContextVariable,
+    PresenceVariable,
+    Constraint,
+    Model,
+    Index,
+)
+from scipy.stats import triang
+
+import numpy as np
+from sympy import Symbol
+
+
+def run() -> np.ndarray:
+    """Runs the model and returns its result."""
+
+    # === Context Variables ===
+    days = [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ]
+    CV_weekday = UniformCategoricalContextVariable("weekday", days)
+
+    # === Presence Variables ===
+    drink_customers = PresenceVariable(
+        name="drink_customers",
+        cvs=[],
+    )
+    food_customers = PresenceVariable(
+        "food_customers",
+        cvs=[],
+    )
+
+    seat_capacity = Index("seat_capacity", 50)
+    # Most common service capacity is 100, ranging from 60 to 100
+    service_capacity = Index("service_capacity", triang(loc=80.0, scale=40.0, c=0.5))
+
+    # Usage of drink customers from the seats available in the bar
+    U_drink_seat = Index("drink customers seat usage factor", 0.2)
+
+    # Usage of food customers from the seats available in the bar
+    U_food_seat = Index("food customers seat usage factor", 0.8)
+
+    # Usage of drink customers from the service
+    U_service_drink = Index("drink customers service usage factor", 0.4)
+
+    # Usage of food customers from the service
+    U_service_food = Index("food customers service usage factor", 0.9)
+
+    # === Constraints ===
+    seat_constraint = Constraint(
+        usage=drink_customers * U_drink_seat + food_customers * U_food_seat,  # type: ignore
+        capacity=seat_capacity,
+    )
+
+    service_constraint = Constraint(
+        usage=food_customers * U_service_food + drink_customers * U_service_drink,  # type: ignore
+        capacity=service_capacity,
+    )
+
+    # === Model ===
+    model = Model(
+        "coffee_shop",
+        cvs=[CV_weekday],
+        pvs=[drink_customers, food_customers],
+        indexes=[
+            seat_capacity,
+            U_drink_seat,
+            U_food_seat,
+            U_service_drink,
+            U_service_food,
+            service_capacity,
+        ],
+        constraints=[seat_constraint, service_constraint],
+        capacities=[seat_capacity, service_capacity],
+    )
+
+    # === Evaluation ===
+    ensemble = Ensemble(model, {CV_weekday: days}, cv_ensemble_size=7)  # type: ignore
+
+    grid = {
+        drink_customers: np.linspace(0, 100, 11),
+        food_customers: np.linspace(0, 100, 11),
+    }
+
+    return model.evaluate(grid, ensemble)
+
+
+if __name__ == "__main__":
+    print(run())


### PR DESCRIPTION
Code adapted from @maryamsajedi code in https://github.com/maryamsajedi/coffee_dt.

Here's the diff between the two models:

```diff
diff --git a/yakof/abtesting/model5/a.py b/yakof/abtesting/model5/b.py
index c2feda8..5f881d6 100644
--- a/yakof/abtesting/model5/a.py
+++ b/yakof/abtesting/model5/b.py
@@ -1,18 +1,16 @@
 """
-A in the A/B testing
+B in the A/B testing
 ====================

-This module contains the original implementation of model5, with minor
-changes required to adapt it for A/B testing.
-
-See https://github.com/maryamsajedi/coffee_dt/blob/master/coffee_dt_5.py.
+This module contains the yakof-based implementation of model5, with minor
+changes from the original, required to use yakof.
 """

-from dt_model import (
+from dt_model import Ensemble
+from yakof.dtlang import (
     UniformCategoricalContextVariable,
     PresenceVariable,
     Constraint,
-    Ensemble,
     Model,
     Index,
 )
@@ -35,7 +33,7 @@ def run() -> np.ndarray:
         "saturday",
         "sunday",
     ]
-    CV_weekday = UniformCategoricalContextVariable("weekday", [Symbol(v) for v in days])
+    CV_weekday = UniformCategoricalContextVariable("weekday", days)

     # === Presence Variables ===
     drink_customers = PresenceVariable(
@@ -92,7 +90,7 @@ def run() -> np.ndarray:
     )

     # === Evaluation ===
-    ensemble = Ensemble(model, {CV_weekday: days}, cv_ensemble_size=7)
+    ensemble = Ensemble(model, {CV_weekday: days}, cv_ensemble_size=7)  # type: ignore

     grid = {
         drink_customers: np.linspace(0, 100, 11),
```