### PR TITLE
BREAKING CHANGE(graph.py): implement infix and prefix operators

### DIFF
--- a/tests/frontend/test_graph.py
+++ b/tests/frontend/test_graph.py
@@ -214,3 +214,202 @@ def test_binary_op_node_ids():
     assert op1.id != op2.id
     assert op1.id != a.id
     assert op1.id != b.id
+
+
+def test_infix_arithmetic_operations():
+    """Test infix arithmetic operations between nodes."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+    c = graph.constant(2.0)
+
+    # Test operator overloading
+    add1 = a + b
+    assert isinstance(add1, graph.add)
+    assert add1.left is a
+    assert add1.right is b
+
+    # Test scalar operations
+    add2 = a + 2.0
+    assert isinstance(add2, graph.add)
+    assert add2.left is a
+    assert isinstance(add2.right, graph.constant)
+    assert add2.right.value == 2.0
+
+    # Test reverse operations
+    add3 = 2.0 + a
+    assert isinstance(add3, graph.add)
+    assert isinstance(add3.left, graph.constant)
+    assert add3.left.value == 2.0
+    assert add3.right is a
+
+    # Test other arithmetic operations
+    sub = a - b
+    assert isinstance(sub, graph.subtract)
+    assert sub.left is a
+    assert sub.right is b
+
+    mul = a * b
+    assert isinstance(mul, graph.multiply)
+    assert mul.left is a
+    assert mul.right is b
+
+    div = a / b
+    assert isinstance(div, graph.divide)
+    assert div.left is a
+    assert div.right is b
+
+
+def test_infix_comparison_operations():
+    """Test infix comparison operations between nodes."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+
+    # Test all comparison operators
+    eq = a == b
+    assert isinstance(eq, graph.equal)
+    assert eq.left is a
+    assert eq.right is b
+
+    ne = a != b
+    assert isinstance(ne, graph.not_equal)
+    assert ne.left is a
+    assert ne.right is b
+
+    lt = a < b
+    assert isinstance(lt, graph.less)
+    assert lt.left is a
+    assert lt.right is b
+
+    le = a <= b
+    assert isinstance(le, graph.less_equal)
+    assert le.left is a
+    assert le.right is b
+
+    gt = a > b
+    assert isinstance(gt, graph.greater)
+    assert gt.left is a
+    assert gt.right is b
+
+    ge = a >= b
+    assert isinstance(ge, graph.greater_equal)
+    assert ge.left is a
+    assert ge.right is b
+
+
+def test_infix_logical_operations():
+    """Test infix logical operations between nodes."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+
+    # Test logical operators
+    and_op = a & b
+    assert isinstance(and_op, graph.logical_and)
+    assert and_op.left is a
+    assert and_op.right is b
+
+    or_op = a | b
+    assert isinstance(or_op, graph.logical_or)
+    assert or_op.left is a
+    assert or_op.right is b
+
+    xor_op = a ^ b
+    assert isinstance(xor_op, graph.logical_xor)
+    assert xor_op.left is a
+    assert xor_op.right is b
+
+    not_op = ~a
+    assert isinstance(not_op, graph.logical_not)
+    assert not_op.node is a
+
+
+def test_infix_reverse_operations():
+    """Test reverse infix operations with scalar values."""
+    a = graph.placeholder("a")
+
+    # Test reverse operations with scalars
+    rsub = 2.0 - a
+    assert isinstance(rsub, graph.subtract)
+    assert isinstance(rsub.left, graph.constant)
+    assert rsub.left.value == 2.0
+    assert rsub.right is a
+
+    rmul = 2.0 * a
+    assert isinstance(rmul, graph.multiply)
+    assert isinstance(rmul.left, graph.constant)
+    assert rmul.left.value == 2.0
+    assert rmul.right is a
+
+    rdiv = 2.0 / a
+    assert isinstance(rdiv, graph.divide)
+    assert isinstance(rdiv.left, graph.constant)
+    assert rdiv.left.value == 2.0
+    assert rdiv.right is a
+
+    # Test reverse logical operations
+    rand = True & a
+    assert isinstance(rand, graph.logical_and)
+    assert isinstance(rand.left, graph.constant)
+    assert rand.left.value is True
+    assert rand.right is a
+
+    ror = True | a
+    assert isinstance(ror, graph.logical_or)
+    assert isinstance(ror.left, graph.constant)
+    assert ror.left.value is True
+    assert ror.right is a
+
+    rxor = True ^ a
+    assert isinstance(rxor, graph.logical_xor)
+    assert isinstance(rxor.left, graph.constant)
+    assert rxor.left.value is True
+    assert rxor.right is a
+
+
+def test_complex_infix_expressions():
+    """Test complex expressions using infix operations."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+    c = graph.placeholder("c")
+
+    # Test complex expression: (a + b) * (c - 2.0)
+    expr = (a + b) * (c - 2.0)
+
+    assert isinstance(expr, graph.multiply)
+    assert isinstance(expr.left, graph.add)
+    assert expr.left.left is a
+    assert expr.left.right is b
+    assert isinstance(expr.right, graph.subtract)
+    assert expr.right.left is c
+    assert isinstance(expr.right.right, graph.constant)
+    assert expr.right.right.value == 2.0
+
+    # Test complex logical expression: (a & b) | (~c)
+    logical_expr = (a & b) | (~c)
+
+    assert isinstance(logical_expr, graph.logical_or)
+    assert isinstance(logical_expr.left, graph.logical_and)
+    assert logical_expr.left.left is a
+    assert logical_expr.left.right is b
+    assert isinstance(logical_expr.right, graph.logical_not)
+    assert logical_expr.right.node is c
+
+
+def test_ensure_node_function():
+    """Test the ensure_node function that converts scalars to constants."""
+    # Test with node input
+    node = graph.placeholder("test")
+    result = graph.ensure_node(node)
+    assert result is node  # Should return the same node
+
+    # Test with scalar inputs
+    result_float = graph.ensure_node(3.14)
+    assert isinstance(result_float, graph.constant)
+    assert result_float.value == 3.14
+
+    result_int = graph.ensure_node(42)
+    assert isinstance(result_int, graph.constant)
+    assert result_int.value == 42
+
+    result_bool = graph.ensure_node(True)
+    assert isinstance(result_bool, graph.constant)
+    assert result_bool.value is True

--- a/tests/frontend/test_linearize.py
+++ b/tests/frontend/test_linearize.py
@@ -7,7 +7,7 @@ import pytest
 from yakof.frontend import graph, linearize
 
 
-def find_node_by_identity(plan, target_node):
+def find_node(plan, target_node):
     """Find the index of a node in the plan using identity comparison.
 
     We MUST use this method for finding the nodes because nodes override
@@ -32,8 +32,8 @@ def test_simple_chain():
     assert len(plan) == 5
 
     # Check node order - dependencies should come before dependents
-    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, b)
-    assert find_node_by_identity(plan, b) < find_node_by_identity(plan, c)
+    assert find_node(plan, a) < find_node(plan, b)
+    assert find_node(plan, b) < find_node(plan, c)
 
     # All nodes should be in the plan
     assert set(n.id for n in plan) == set(n.id for n in {a, b, c, b.right, c.right})
@@ -52,16 +52,12 @@ def test_diamond_graph():
     assert len(plan) == 6
 
     # x should come before both branches
-    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, left_branch)
-    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, right_branch)
+    assert find_node(plan, x) < find_node(plan, left_branch)
+    assert find_node(plan, x) < find_node(plan, right_branch)
 
     # Both branches should come before output
-    assert find_node_by_identity(plan, left_branch) < find_node_by_identity(
-        plan, output
-    )
-    assert find_node_by_identity(plan, right_branch) < find_node_by_identity(
-        plan, output
-    )
+    assert find_node(plan, left_branch) < find_node(plan, output)
+    assert find_node(plan, right_branch) < find_node(plan, output)
 
 
 def test_multi_output():
@@ -76,8 +72,8 @@ def test_multi_output():
     assert len(plan) == 5
 
     # Dependencies should come before dependents
-    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, b)
-    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, c)
+    assert find_node(plan, a) < find_node(plan, b)
+    assert find_node(plan, a) < find_node(plan, c)
 
 
 def test_shared_subgraph():
@@ -98,10 +94,10 @@ def test_shared_subgraph():
     assert len([n for n in plan if n is common]) == 1
 
     # Check dependencies
-    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, common)
-    assert find_node_by_identity(plan, b) < find_node_by_identity(plan, common)
-    assert find_node_by_identity(plan, common) < find_node_by_identity(plan, out1)
-    assert find_node_by_identity(plan, common) < find_node_by_identity(plan, out2)
+    assert find_node(plan, a) < find_node(plan, common)
+    assert find_node(plan, b) < find_node(plan, common)
+    assert find_node(plan, common) < find_node(plan, out1)
+    assert find_node(plan, common) < find_node(plan, out2)
 
 
 def test_cycle_detection():
@@ -129,9 +125,9 @@ def test_conditional_nodes():
     plan = linearize.forest(where_result)
 
     # Check dependencies
-    assert find_node_by_identity(plan, cond) < find_node_by_identity(plan, where_result)
-    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, where_result)
-    assert find_node_by_identity(plan, y) < find_node_by_identity(plan, where_result)
+    assert find_node(plan, cond) < find_node(plan, where_result)
+    assert find_node(plan, x) < find_node(plan, where_result)
+    assert find_node(plan, y) < find_node(plan, where_result)
 
     # Multi-clause where
     clauses = [(cond, x), (graph.less(x, y), graph.constant(1.0))]
@@ -140,9 +136,9 @@ def test_conditional_nodes():
     plan = linearize.forest(multi_where)
 
     # Check dependencies
-    assert find_node_by_identity(plan, cond) < find_node_by_identity(plan, multi_where)
-    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, multi_where)
-    assert find_node_by_identity(plan, y) < find_node_by_identity(plan, multi_where)
+    assert find_node(plan, cond) < find_node(plan, multi_where)
+    assert find_node(plan, x) < find_node(plan, multi_where)
+    assert find_node(plan, y) < find_node(plan, multi_where)
 
 
 def test_complex_graph():
@@ -167,17 +163,17 @@ def test_complex_graph():
     plan = linearize.forest(h)
 
     # Check dependencies
-    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, a)
-    assert find_node_by_identity(plan, y) < find_node_by_identity(plan, b)
-    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, c)
-    assert find_node_by_identity(plan, b) < find_node_by_identity(plan, c)
-    assert find_node_by_identity(plan, y) < find_node_by_identity(plan, d)
-    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, e)
-    assert find_node_by_identity(plan, e) < find_node_by_identity(plan, f)
-    assert find_node_by_identity(plan, d) < find_node_by_identity(plan, g)
-    assert find_node_by_identity(plan, f) < find_node_by_identity(plan, g)
-    assert find_node_by_identity(plan, c) < find_node_by_identity(plan, h)
-    assert find_node_by_identity(plan, g) < find_node_by_identity(plan, h)
+    assert find_node(plan, x) < find_node(plan, a)
+    assert find_node(plan, y) < find_node(plan, b)
+    assert find_node(plan, a) < find_node(plan, c)
+    assert find_node(plan, b) < find_node(plan, c)
+    assert find_node(plan, y) < find_node(plan, d)
+    assert find_node(plan, x) < find_node(plan, e)
+    assert find_node(plan, e) < find_node(plan, f)
+    assert find_node(plan, d) < find_node(plan, g)
+    assert find_node(plan, f) < find_node(plan, g)
+    assert find_node(plan, c) < find_node(plan, h)
+    assert find_node(plan, g) < find_node(plan, h)
 
 
 def test_axes_operations():
@@ -191,8 +187,8 @@ def test_axes_operations():
     plan = linearize.forest(reduced)
 
     # Check node ordering
-    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, expanded)
-    assert find_node_by_identity(plan, expanded) < find_node_by_identity(plan, reduced)
+    assert find_node(plan, x) < find_node(plan, expanded)
+    assert find_node(plan, expanded) < find_node(plan, reduced)
 
 
 def test_multiple_independent_graphs():
@@ -208,8 +204,8 @@ def test_multiple_independent_graphs():
     # Check plan - independent graphs can be linearized in any order
     # but dependencies should still be respected
     assert len(plan) == 4
-    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, a_result)
-    assert find_node_by_identity(plan, b) < find_node_by_identity(plan, b_result)
+    assert find_node(plan, a) < find_node(plan, a_result)
+    assert find_node(plan, b) < find_node(plan, b_result)
 
 
 def test_deterministic_ordering():

--- a/tests/frontend/test_linearize.py
+++ b/tests/frontend/test_linearize.py
@@ -7,6 +7,19 @@ import pytest
 from yakof.frontend import graph, linearize
 
 
+def find_node_by_identity(plan, target_node):
+    """Find the index of a node in the plan using identity comparison.
+
+    We MUST use this method for finding the nodes because nodes override
+    their __eq__ method to implement lazy comparison."""
+
+    for idx, node in enumerate(plan):
+        if target_node is node:
+            return idx
+
+    raise ValueError(f"Node {target_node.id} not found in plan")
+
+
 def test_simple_chain():
     """Test linearization of a simple linear chain of nodes."""
     a = graph.placeholder("a")
@@ -19,11 +32,11 @@ def test_simple_chain():
     assert len(plan) == 5
 
     # Check node order - dependencies should come before dependents
-    assert plan.index(a) < plan.index(b)
-    assert plan.index(b) < plan.index(c)
+    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, b)
+    assert find_node_by_identity(plan, b) < find_node_by_identity(plan, c)
 
     # All nodes should be in the plan
-    assert set(plan) == {a, b, c, b.right, c.right}
+    assert set(n.id for n in plan) == set(n.id for n in {a, b, c, b.right, c.right})
 
 
 def test_diamond_graph():
@@ -39,12 +52,12 @@ def test_diamond_graph():
     assert len(plan) == 6
 
     # x should come before both branches
-    assert plan.index(x) < plan.index(left_branch)
-    assert plan.index(x) < plan.index(right_branch)
+    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, left_branch)
+    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, right_branch)
 
     # Both branches should come before output
-    assert plan.index(left_branch) < plan.index(output)
-    assert plan.index(right_branch) < plan.index(output)
+    assert find_node_by_identity(plan, left_branch) < find_node_by_identity(plan, output)
+    assert find_node_by_identity(plan, right_branch) < find_node_by_identity(plan, output)
 
 
 def test_multi_output():
@@ -59,8 +72,8 @@ def test_multi_output():
     assert len(plan) == 5
 
     # Dependencies should come before dependents
-    assert plan.index(a) < plan.index(b)
-    assert plan.index(a) < plan.index(c)
+    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, b)
+    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, c)
 
 
 def test_shared_subgraph():
@@ -81,10 +94,10 @@ def test_shared_subgraph():
     assert len([n for n in plan if n is common]) == 1
 
     # Check dependencies
-    assert plan.index(a) < plan.index(common)
-    assert plan.index(b) < plan.index(common)
-    assert plan.index(common) < plan.index(out1)
-    assert plan.index(common) < plan.index(out2)
+    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, common)
+    assert find_node_by_identity(plan, b) < find_node_by_identity(plan, common)
+    assert find_node_by_identity(plan, common) < find_node_by_identity(plan, out1)
+    assert find_node_by_identity(plan, common) < find_node_by_identity(plan, out2)
 
 
 def test_cycle_detection():
@@ -112,9 +125,9 @@ def test_conditional_nodes():
     plan = linearize.forest(where_result)
 
     # Check dependencies
-    assert plan.index(cond) < plan.index(where_result)
-    assert plan.index(x) < plan.index(where_result)
-    assert plan.index(y) < plan.index(where_result)
+    assert find_node_by_identity(plan, cond) < find_node_by_identity(plan, where_result)
+    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, where_result)
+    assert find_node_by_identity(plan, y) < find_node_by_identity(plan, where_result)
 
     # Multi-clause where
     clauses = [(cond, x), (graph.less(x, y), graph.constant(1.0))]
@@ -123,9 +136,9 @@ def test_conditional_nodes():
     plan = linearize.forest(multi_where)
 
     # Check dependencies
-    assert plan.index(cond) < plan.index(multi_where)
-    assert plan.index(x) < plan.index(multi_where)
-    assert plan.index(y) < plan.index(multi_where)
+    assert find_node_by_identity(plan, cond) < find_node_by_identity(plan, multi_where)
+    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, multi_where)
+    assert find_node_by_identity(plan, y) < find_node_by_identity(plan, multi_where)
 
 
 def test_complex_graph():
@@ -150,17 +163,17 @@ def test_complex_graph():
     plan = linearize.forest(h)
 
     # Check dependencies
-    assert plan.index(x) < plan.index(a)
-    assert plan.index(y) < plan.index(b)
-    assert plan.index(a) < plan.index(c)
-    assert plan.index(b) < plan.index(c)
-    assert plan.index(y) < plan.index(d)
-    assert plan.index(x) < plan.index(e)
-    assert plan.index(e) < plan.index(f)
-    assert plan.index(d) < plan.index(g)
-    assert plan.index(f) < plan.index(g)
-    assert plan.index(c) < plan.index(h)
-    assert plan.index(g) < plan.index(h)
+    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, a)
+    assert find_node_by_identity(plan, y) < find_node_by_identity(plan, b)
+    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, c)
+    assert find_node_by_identity(plan, b) < find_node_by_identity(plan, c)
+    assert find_node_by_identity(plan, y) < find_node_by_identity(plan, d)
+    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, e)
+    assert find_node_by_identity(plan, e) < find_node_by_identity(plan, f)
+    assert find_node_by_identity(plan, d) < find_node_by_identity(plan, g)
+    assert find_node_by_identity(plan, f) < find_node_by_identity(plan, g)
+    assert find_node_by_identity(plan, c) < find_node_by_identity(plan, h)
+    assert find_node_by_identity(plan, g) < find_node_by_identity(plan, h)
 
 
 def test_axes_operations():
@@ -174,8 +187,8 @@ def test_axes_operations():
     plan = linearize.forest(reduced)
 
     # Check node ordering
-    assert plan.index(x) < plan.index(expanded)
-    assert plan.index(expanded) < plan.index(reduced)
+    assert find_node_by_identity(plan, x) < find_node_by_identity(plan, expanded)
+    assert find_node_by_identity(plan, expanded) < find_node_by_identity(plan, reduced)
 
 
 def test_multiple_independent_graphs():
@@ -191,8 +204,8 @@ def test_multiple_independent_graphs():
     # Check plan - independent graphs can be linearized in any order
     # but dependencies should still be respected
     assert len(plan) == 4
-    assert plan.index(a) < plan.index(a_result)
-    assert plan.index(b) < plan.index(b_result)
+    assert find_node_by_identity(plan, a) < find_node_by_identity(plan, a_result)
+    assert find_node_by_identity(plan, b) < find_node_by_identity(plan, b_result)
 
 
 def test_deterministic_ordering():

--- a/tests/frontend/test_linearize.py
+++ b/tests/frontend/test_linearize.py
@@ -56,8 +56,12 @@ def test_diamond_graph():
     assert find_node_by_identity(plan, x) < find_node_by_identity(plan, right_branch)
 
     # Both branches should come before output
-    assert find_node_by_identity(plan, left_branch) < find_node_by_identity(plan, output)
-    assert find_node_by_identity(plan, right_branch) < find_node_by_identity(plan, output)
+    assert find_node_by_identity(plan, left_branch) < find_node_by_identity(
+        plan, output
+    )
+    assert find_node_by_identity(plan, right_branch) < find_node_by_identity(
+        plan, output
+    )
 
 
 def test_multi_output():

--- a/yakof/frontend/graph.py
+++ b/yakof/frontend/graph.py
@@ -4,7 +4,7 @@ Computation Graph Building
 
 This module allows to build an abstract computation graph using TensorFlow-like
 computation primitives and concepts. These primitives and concepts are also similar
-to NumPy primitives, with minor naming differences.
+to NumPy primitives, albeit with minor naming differences.
 
 This module provides:
 
@@ -15,6 +15,8 @@ This module provides:
 5. Mathematical operations (exp, power, log)
 6. Shape manipulation operations (expand_dims, squeeze)
 7. Reduction operations (sum, mean)
+8. Built-in debug operations (tracepoint, breakpoint)
+9. Support for infix and unary operators (e.g., `a + b`, `~a`)
 
 The nodes form a directed acyclic graph (DAG) that represents computations
 to be performed. Each node implements a specific operation and stores its
@@ -42,8 +44,8 @@ Here's an example of what you can do with this module:
     >>>
     >>> a = graph.placeholder("a", 1.0)
     >>> b = graph.constant(2.0)
-    >>> c = graph.add(a, b)
-    >>> d = grap.multiply(c, c)
+    >>> c = a + b
+    >>> d = c * c + 1
     >>>
     >>> # Expand to a higher-dimensional space
     >>> e = graph.expand_dims(d, axis=(1,2))
@@ -110,6 +112,11 @@ _id_generator = atomic.Int()
 """Atomic integer generator for unique node IDs."""
 
 
+def ensure_node(value: Node | Scalar) -> Node:
+    """Converts a scalar value to a constant node if necessary."""
+    return value if isinstance(value, Node) else constant(value)
+
+
 class Node:
     """
     Base class for all computation graph nodes.
@@ -134,12 +141,77 @@ class Node:
         self.id = _id_generator.add(1)
 
     def __hash__(self) -> int:
-        # Note: introducing hashing by identity in the class inheritance
-        # chain to ensure that overriding the equality operator type signature
-        # in derived classes does not break assigning to dicts.
-        #
-        # See also the implementation of Tensor[B].__eq__ in abstract.py.
+        # Note: we need to implement identity based hashing because we
+        # override the `__eq__` method to support lazy equality.
         return id(self)
+
+    # Arithmetic operators
+    def __add__(self, other: Node | Scalar) -> Node:
+        return add(self, ensure_node(other))
+
+    def __radd__(self, other: Node | Scalar) -> Node:
+        return add(ensure_node(other), self)
+
+    def __sub__(self, other: Node | Scalar) -> Node:
+        return subtract(self, ensure_node(other))
+
+    def __rsub__(self, other: Node | Scalar) -> Node:
+        return subtract(ensure_node(other), self)
+
+    def __mul__(self, other: Node | Scalar) -> Node:
+        return multiply(self, ensure_node(other))
+
+    def __rmul__(self, other: Node | Scalar) -> Node:
+        return multiply(ensure_node(other), self)
+
+    def __truediv__(self, other: Node | Scalar) -> Node:
+        return divide(self, ensure_node(other))
+
+    def __rtruediv__(self, other: Node | Scalar) -> Node:
+        return divide(ensure_node(other), self)
+
+    # Comparison operators
+    #
+    # See the companion `__hash__` comment.
+    def __eq__(self, other: Node | Scalar) -> Node:  # type: ignore
+        return equal(self, ensure_node(other))
+
+    def __ne__(self, other: Node | Scalar) -> Node:  # type: ignore
+        return not_equal(self, ensure_node(other))
+
+    def __lt__(self, other: Node | Scalar) -> Node:
+        return less(self, ensure_node(other))
+
+    def __le__(self, other: Node | Scalar) -> Node:
+        return less_equal(self, ensure_node(other))
+
+    def __gt__(self, other: Node | Scalar) -> Node:
+        return greater(self, ensure_node(other))
+
+    def __ge__(self, other: Node | Scalar) -> Node:
+        return greater_equal(self, ensure_node(other))
+
+    # Logical operators
+    def __and__(self, other: Node | Scalar) -> Node:
+        return logical_and(self, ensure_node(other))
+
+    def __rand__(self, other: Node | Scalar) -> Node:
+        return logical_and(ensure_node(other), self)
+
+    def __or__(self, other: Node | Scalar) -> Node:
+        return logical_or(self, ensure_node(other))
+
+    def __ror__(self, other: Node | Scalar) -> Node:
+        return logical_or(ensure_node(other), self)
+
+    def __xor__(self, other: Node | Scalar) -> Node:
+        return logical_xor(self, ensure_node(other))
+
+    def __rxor__(self, other: Node | Scalar) -> Node:
+        return logical_xor(ensure_node(other), self)
+
+    def __invert__(self) -> Node:
+        return logical_not(self)
 
 
 class constant(Node):

--- a/yakof/frontend/graph.py
+++ b/yakof/frontend/graph.py
@@ -83,6 +83,29 @@ Design Decisions
 3. Node Identity:
    - Nodes are identified by their instance identity
    - Enables graph traversal and transformation
+
+Node Identity and Equality
+--------------------------
+
+Nodes in this module override Python's standard equality operators (`==`, `!=`, etc.)
+to create new graph operations rather than test for object equality.
+
+For example:
+    x == y   # Creates a graph.equal operation node
+    x < y    # Creates a graph.less operation node
+
+When you need to check if two nodes are the same object (identity comparison),
+use Python's `is` operator instead:
+
+    x is y   # Tests if x and y are the same object
+
+This behavior impacts code that needs to find nodes in collections like lists:
+
+    # Won't work as expected:
+    nodes.index(my_node)  # Uses `==` internally
+
+    # Correct approach:
+    next(i for i, n in enumerate(nodes) if n is my_node)
 """
 
 # SPDX-License-Identifier: Apache-2.0

--- a/yakof/frontend/linearize.py
+++ b/yakof/frontend/linearize.py
@@ -19,6 +19,18 @@ This is useful for:
 - Creating efficient execution plans for evaluators
 - Visualizing the computation flow in order
 - Debugging models by inspecting operations in a logical sequence
+
+Note on Node Identity
+--------------------
+Because nodes override equality operators to build computation graphs,
+finding nodes within the execution plan must use object identity (`is`),
+not equality comparison (`==`).
+
+Use the provided `find_node()` function to locate nodes in the plan:
+    position = find_node(plan, target_node)
+
+Do not use:
+    position = plan.index(target_node)  # Will not work correctly
 """
 
 # SPDX-License-Identifier: Apache-2.0
@@ -60,6 +72,10 @@ def forest(*leaves: graph.Node) -> list[graph.Node]:
         >>>
         >>> # List of outputs
         >>> plan = linearize.forest(*output_list)
+
+    Note: because nodes override their equality operators to build computation
+    graphs, finding nodes within the execution plan must use object identity, as
+    documented more extensively in the `graph` and in this module's docstring.
     """
 
     # plan contains the linearized output


### PR DESCRIPTION
This diff implements infix and prefix operators to allow for gradual migration of the dt_model to use typed tensors. These operators significantly improve code readability and ergonomics for graph construction.

We also add tests to ensure the new code is working as intended.

This change is marked as breaking because we have overridden a bunch of built-in methods (`__eq__`, `__add__`, etc.) to operate lazily. The end result is that we have needed to rewrite test_linearize.py quite significantly, and potentially other existing code that relied on object identity checks might break.

However, I believe that the advantages in terms of usage ergonomics and enabling gradual adoption of yakof features outweigh these drawbacks. This pattern aligns us a bit more with TensorFlow v1.x.