### PR TITLE
feat(molveno): add the original Molveno model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "yakof"
 version = "0.1.0"
 description = "A technology demonstrator for sustainability modeling"
 requires-python = "==3.11.11"
-dependencies = ["scipy", "dt-model", "numpy", "sympy"]
+dependencies = ["dt_model", "matplotlib", "numpy", "pandas", "scipy", "sympy"]
 license = "Apache-2.0"
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,27 @@ wheels = [
 ]
 
 [[package]]
+name = "contourpy"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/c2/fc7193cc5383637ff390a712e88e4ded0452c9fbcf84abe3de5ea3df1866/contourpy-1.3.1.tar.gz", hash = "sha256:dfd97abd83335045a913e3bcc4a09c0ceadbe66580cf573fe961f4a825efa699", size = 13465753 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/bb/11250d2906ee2e8b466b5f93e6b19d525f3e0254ac8b445b56e618527718/contourpy-1.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3e8b974d8db2c5610fb4e76307e265de0edb655ae8169e8b21f41807ccbeec4b", size = 269555 },
+    { url = "https://files.pythonhosted.org/packages/67/71/1e6e95aee21a500415f5d2dbf037bf4567529b6a4e986594d7026ec5ae90/contourpy-1.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:20914c8c973f41456337652a6eeca26d2148aa96dd7ac323b74516988bea89fc", size = 254549 },
+    { url = "https://files.pythonhosted.org/packages/31/2c/b88986e8d79ac45efe9d8801ae341525f38e087449b6c2f2e6050468a42c/contourpy-1.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19d40d37c1c3a4961b4619dd9d77b12124a453cc3d02bb31a07d58ef684d3d86", size = 313000 },
+    { url = "https://files.pythonhosted.org/packages/c4/18/65280989b151fcf33a8352f992eff71e61b968bef7432fbfde3a364f0730/contourpy-1.3.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:113231fe3825ebf6f15eaa8bc1f5b0ddc19d42b733345eae0934cb291beb88b6", size = 352925 },
+    { url = "https://files.pythonhosted.org/packages/f5/c7/5fd0146c93220dbfe1a2e0f98969293b86ca9bc041d6c90c0e065f4619ad/contourpy-1.3.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4dbbc03a40f916a8420e420d63e96a1258d3d1b58cbdfd8d1f07b49fcbd38e85", size = 323693 },
+    { url = "https://files.pythonhosted.org/packages/85/fc/7fa5d17daf77306840a4e84668a48ddff09e6bc09ba4e37e85ffc8e4faa3/contourpy-1.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a04ecd68acbd77fa2d39723ceca4c3197cb2969633836ced1bea14e219d077c", size = 326184 },
+    { url = "https://files.pythonhosted.org/packages/ef/e7/104065c8270c7397c9571620d3ab880558957216f2b5ebb7e040f85eeb22/contourpy-1.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c414fc1ed8ee1dbd5da626cf3710c6013d3d27456651d156711fa24f24bd1291", size = 1268031 },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/c788d0bdbf32c8113c2354493ed291f924d4793c4a2e85b69e737a21a658/contourpy-1.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:31c1b55c1f34f80557d3830d3dd93ba722ce7e33a0b472cba0ec3b6535684d8f", size = 1325995 },
+    { url = "https://files.pythonhosted.org/packages/a6/e6/a2f351a90d955f8b0564caf1ebe4b1451a3f01f83e5e3a414055a5b8bccb/contourpy-1.3.1-cp311-cp311-win32.whl", hash = "sha256:f611e628ef06670df83fce17805c344710ca5cde01edfdc72751311da8585375", size = 174396 },
+    { url = "https://files.pythonhosted.org/packages/a8/7e/cd93cab453720a5d6cb75588cc17dcdc08fc3484b9de98b885924ff61900/contourpy-1.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:b2bdca22a27e35f16794cf585832e542123296b4687f9fd96822db6bae17bfc9", size = 219787 },
+]
+
+[[package]]
 name = "coverage"
 version = "7.6.12"
 source = { registry = "https://pypi.org/simple" }
@@ -63,6 +84,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321 },
+]
+
+[[package]]
 name = "dt-model"
 version = "0.0.1"
 source = { git = "https://github.com/fbk-most/dt-model?rev=main#efded93eee8956508faa265b3c5e071a48d11b23" }
@@ -74,12 +104,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "fonttools"
+version = "4.56.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/8c/9ffa2a555af0e5e5d0e2ed7fdd8c9bef474ed676995bb4c57c9cd0014248/fonttools-4.56.0.tar.gz", hash = "sha256:a114d1567e1a1586b7e9e7fc2ff686ca542a82769a296cef131e4c4af51e58f4", size = 3462892 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/56/a2f3e777d48fcae7ecd29de4d96352d84e5ea9871e5f3fc88241521572cf/fonttools-4.56.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ef04bc7827adb7532be3d14462390dd71287644516af3f1e67f1e6ff9c6d6df", size = 2753325 },
+    { url = "https://files.pythonhosted.org/packages/71/85/d483e9c4e5ed586b183bf037a353e8d766366b54fd15519b30e6178a6a6e/fonttools-4.56.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ffda9b8cd9cb8b301cae2602ec62375b59e2e2108a117746f12215145e3f786c", size = 2281554 },
+    { url = "https://files.pythonhosted.org/packages/09/67/060473b832b2fade03c127019794df6dc02d9bc66fa4210b8e0d8a99d1e5/fonttools-4.56.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e993e8db36306cc3f1734edc8ea67906c55f98683d6fd34c3fc5593fdbba4c", size = 4869260 },
+    { url = "https://files.pythonhosted.org/packages/28/e9/47c02d5a7027e8ed841ab6a10ca00c93dadd5f16742f1af1fa3f9978adf4/fonttools-4.56.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:003548eadd674175510773f73fb2060bb46adb77c94854af3e0cc5bc70260049", size = 4898508 },
+    { url = "https://files.pythonhosted.org/packages/bf/8a/221d456d1afb8ca043cfd078f59f187ee5d0a580f4b49351b9ce95121f57/fonttools-4.56.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd9825822e7bb243f285013e653f6741954d8147427aaa0324a862cdbf4cbf62", size = 4877700 },
+    { url = "https://files.pythonhosted.org/packages/a4/8c/e503863adf7a6aeff7b960e2f66fa44dd0c29a7a8b79765b2821950d7b05/fonttools-4.56.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b23d30a2c0b992fb1c4f8ac9bfde44b5586d23457759b6cf9a787f1a35179ee0", size = 5045817 },
+    { url = "https://files.pythonhosted.org/packages/2b/50/79ba3b7e42f4eaa70b82b9e79155f0f6797858dc8a97862428b6852c6aee/fonttools-4.56.0-cp311-cp311-win32.whl", hash = "sha256:47b5e4680002ae1756d3ae3b6114e20aaee6cc5c69d1e5911f5ffffd3ee46c6b", size = 2154426 },
+    { url = "https://files.pythonhosted.org/packages/3b/90/4926e653041c4116ecd43e50e3c79f5daae6dcafc58ceb64bc4f71dd4924/fonttools-4.56.0-cp311-cp311-win_amd64.whl", hash = "sha256:14a3e3e6b211660db54ca1ef7006401e4a694e53ffd4553ab9bc87ead01d0f05", size = 2200937 },
+    { url = "https://files.pythonhosted.org/packages/bf/ff/44934a031ce5a39125415eb405b9efb76fe7f9586b75291d66ae5cbfc4e6/fonttools-4.56.0-py3-none-any.whl", hash = "sha256:1088182f68c303b50ca4dc0c82d42083d176cba37af1937e1a976a31149d4d14", size = 1089800 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.4.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/59/7c91426a8ac292e1cdd53a63b6d9439abd573c875c3f92c146767dd33faf/kiwisolver-1.4.8.tar.gz", hash = "sha256:23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e", size = 97538 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/ed/c913ee28936c371418cb167b128066ffb20bbf37771eecc2c97edf8a6e4c/kiwisolver-1.4.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a4d3601908c560bdf880f07d94f31d734afd1bb71e96585cace0e38ef44c6d84", size = 124635 },
+    { url = "https://files.pythonhosted.org/packages/4c/45/4a7f896f7467aaf5f56ef093d1f329346f3b594e77c6a3c327b2d415f521/kiwisolver-1.4.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:856b269c4d28a5c0d5e6c1955ec36ebfd1651ac00e1ce0afa3e28da95293b561", size = 66717 },
+    { url = "https://files.pythonhosted.org/packages/5f/b4/c12b3ac0852a3a68f94598d4c8d569f55361beef6159dce4e7b624160da2/kiwisolver-1.4.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c2b9a96e0f326205af81a15718a9073328df1173a2619a68553decb7097fd5d7", size = 65413 },
+    { url = "https://files.pythonhosted.org/packages/a9/98/1df4089b1ed23d83d410adfdc5947245c753bddfbe06541c4aae330e9e70/kiwisolver-1.4.8-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5020c83e8553f770cb3b5fc13faac40f17e0b205bd237aebd21d53d733adb03", size = 1343994 },
+    { url = "https://files.pythonhosted.org/packages/8d/bf/b4b169b050c8421a7c53ea1ea74e4ef9c335ee9013216c558a047f162d20/kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dace81d28c787956bfbfbbfd72fdcef014f37d9b48830829e488fdb32b49d954", size = 1434804 },
+    { url = "https://files.pythonhosted.org/packages/66/5a/e13bd341fbcf73325ea60fdc8af752addf75c5079867af2e04cc41f34434/kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:11e1022b524bd48ae56c9b4f9296bce77e15a2e42a502cceba602f804b32bb79", size = 1450690 },
+    { url = "https://files.pythonhosted.org/packages/9b/4f/5955dcb376ba4a830384cc6fab7d7547bd6759fe75a09564910e9e3bb8ea/kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b9b4d2892fefc886f30301cdd80debd8bb01ecdf165a449eb6e78f79f0fabd6", size = 1376839 },
+    { url = "https://files.pythonhosted.org/packages/3a/97/5edbed69a9d0caa2e4aa616ae7df8127e10f6586940aa683a496c2c280b9/kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a96c0e790ee875d65e340ab383700e2b4891677b7fcd30a699146f9384a2bb0", size = 1435109 },
+    { url = "https://files.pythonhosted.org/packages/13/fc/e756382cb64e556af6c1809a1bbb22c141bbc2445049f2da06b420fe52bf/kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:23454ff084b07ac54ca8be535f4174170c1094a4cff78fbae4f73a4bcc0d4dab", size = 2245269 },
+    { url = "https://files.pythonhosted.org/packages/76/15/e59e45829d7f41c776d138245cabae6515cb4eb44b418f6d4109c478b481/kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:87b287251ad6488e95b4f0b4a79a6d04d3ea35fde6340eb38fbd1ca9cd35bbbc", size = 2393468 },
+    { url = "https://files.pythonhosted.org/packages/e9/39/483558c2a913ab8384d6e4b66a932406f87c95a6080112433da5ed668559/kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b21dbe165081142b1232a240fc6383fd32cdd877ca6cc89eab93e5f5883e1c25", size = 2355394 },
+    { url = "https://files.pythonhosted.org/packages/01/aa/efad1fbca6570a161d29224f14b082960c7e08268a133fe5dc0f6906820e/kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:768cade2c2df13db52475bd28d3a3fac8c9eff04b0e9e2fda0f3760f20b3f7fc", size = 2490901 },
+    { url = "https://files.pythonhosted.org/packages/c9/4f/15988966ba46bcd5ab9d0c8296914436720dd67fca689ae1a75b4ec1c72f/kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d47cfb2650f0e103d4bf68b0b5804c68da97272c84bb12850d877a95c056bd67", size = 2312306 },
+    { url = "https://files.pythonhosted.org/packages/2d/27/bdf1c769c83f74d98cbc34483a972f221440703054894a37d174fba8aa68/kiwisolver-1.4.8-cp311-cp311-win_amd64.whl", hash = "sha256:ed33ca2002a779a2e20eeb06aea7721b6e47f2d4b8a8ece979d8ba9e2a167e34", size = 71966 },
+    { url = "https://files.pythonhosted.org/packages/4a/c9/9642ea855604aeb2968a8e145fc662edf61db7632ad2e4fb92424be6b6c0/kiwisolver-1.4.8-cp311-cp311-win_arm64.whl", hash = "sha256:16523b40aab60426ffdebe33ac374457cf62863e330a90a0383639ce14bf44b2", size = 65311 },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/08/b89867ecea2e305f408fbb417139a8dd941ecf7b23a2e02157c36da546f0/matplotlib-3.10.1.tar.gz", hash = "sha256:e8d2d0e3881b129268585bf4765ad3ee73a4591d77b9a18c214ac7e3a79fb2ba", size = 36743335 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/14/a1b840075be247bb1834b22c1e1d558740b0f618fe3a823740181ca557a1/matplotlib-3.10.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:057206ff2d6ab82ff3e94ebd94463d084760ca682ed5f150817b859372ec4401", size = 8174669 },
+    { url = "https://files.pythonhosted.org/packages/0a/e4/300b08e3e08f9c98b0d5635f42edabf2f7a1d634e64cb0318a71a44ff720/matplotlib-3.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a144867dd6bf8ba8cb5fc81a158b645037e11b3e5cf8a50bd5f9917cb863adfe", size = 8047996 },
+    { url = "https://files.pythonhosted.org/packages/75/f9/8d99ff5a2498a5f1ccf919fb46fb945109623c6108216f10f96428f388bc/matplotlib-3.10.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56c5d9fcd9879aa8040f196a235e2dcbdf7dd03ab5b07c0696f80bc6cf04bedd", size = 8461612 },
+    { url = "https://files.pythonhosted.org/packages/40/b8/53fa08a5eaf78d3a7213fd6da1feec4bae14a81d9805e567013811ff0e85/matplotlib-3.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f69dc9713e4ad2fb21a1c30e37bd445d496524257dfda40ff4a8efb3604ab5c", size = 8602258 },
+    { url = "https://files.pythonhosted.org/packages/40/87/4397d2ce808467af86684a622dd112664553e81752ea8bf61bdd89d24a41/matplotlib-3.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4c59af3e8aca75d7744b68e8e78a669e91ccbcf1ac35d0102a7b1b46883f1dd7", size = 9408896 },
+    { url = "https://files.pythonhosted.org/packages/d7/68/0d03098b3feb786cbd494df0aac15b571effda7f7cbdec267e8a8d398c16/matplotlib-3.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:11b65088c6f3dae784bc72e8d039a2580186285f87448babb9ddb2ad0082993a", size = 8061281 },
 ]
 
 [[package]]
@@ -158,6 +253,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz", hash = "sha256:368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20", size = 46742715 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/d6/2000bfd8d5414fb70cbbe52c8332f2283ff30ed66a9cde42716c8ecbe22c/pillow-11.1.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:e06695e0326d05b06833b40b7ef477e475d0b1ba3a6d27da1bb48c23209bf457", size = 3229968 },
+    { url = "https://files.pythonhosted.org/packages/d9/45/3fe487010dd9ce0a06adf9b8ff4f273cc0a44536e234b0fad3532a42c15b/pillow-11.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96f82000e12f23e4f29346e42702b6ed9a2f2fea34a740dd5ffffcc8c539eb35", size = 3101806 },
+    { url = "https://files.pythonhosted.org/packages/e3/72/776b3629c47d9d5f1c160113158a7a7ad177688d3a1159cd3b62ded5a33a/pillow-11.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3cd561ded2cf2bbae44d4605837221b987c216cff94f49dfeed63488bb228d2", size = 4322283 },
+    { url = "https://files.pythonhosted.org/packages/e4/c2/e25199e7e4e71d64eeb869f5b72c7ddec70e0a87926398785ab944d92375/pillow-11.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f189805c8be5ca5add39e6f899e6ce2ed824e65fb45f3c28cb2841911da19070", size = 4402945 },
+    { url = "https://files.pythonhosted.org/packages/c1/ed/51d6136c9d5911f78632b1b86c45241c712c5a80ed7fa7f9120a5dff1eba/pillow-11.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:dd0052e9db3474df30433f83a71b9b23bd9e4ef1de13d92df21a52c0303b8ab6", size = 4361228 },
+    { url = "https://files.pythonhosted.org/packages/48/a4/fbfe9d5581d7b111b28f1d8c2762dee92e9821bb209af9fa83c940e507a0/pillow-11.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:837060a8599b8f5d402e97197d4924f05a2e0d68756998345c829c33186217b1", size = 4484021 },
+    { url = "https://files.pythonhosted.org/packages/39/db/0b3c1a5018117f3c1d4df671fb8e47d08937f27519e8614bbe86153b65a5/pillow-11.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:aa8dd43daa836b9a8128dbe7d923423e5ad86f50a7a14dc688194b7be5c0dea2", size = 4287449 },
+    { url = "https://files.pythonhosted.org/packages/d9/58/bc128da7fea8c89fc85e09f773c4901e95b5936000e6f303222490c052f3/pillow-11.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0a2f91f8a8b367e7a57c6e91cd25af510168091fb89ec5146003e424e1558a96", size = 4419972 },
+    { url = "https://files.pythonhosted.org/packages/5f/bb/58f34379bde9fe197f51841c5bbe8830c28bbb6d3801f16a83b8f2ad37df/pillow-11.1.0-cp311-cp311-win32.whl", hash = "sha256:c12fc111ef090845de2bb15009372175d76ac99969bdf31e2ce9b42e4b8cd88f", size = 2291201 },
+    { url = "https://files.pythonhosted.org/packages/3a/c6/fce9255272bcf0c39e15abd2f8fd8429a954cf344469eaceb9d0d1366913/pillow-11.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fbd43429d0d7ed6533b25fc993861b8fd512c42d04514a0dd6337fb3ccf22761", size = 2625686 },
+    { url = "https://files.pythonhosted.org/packages/c8/52/8ba066d569d932365509054859f74f2a9abee273edcef5cd75e4bc3e831e/pillow-11.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:f7955ecf5609dee9442cbface754f2c6e541d9e6eda87fad7f7a989b0bdb9d71", size = 2375194 },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -173,6 +287,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/1a/3544f4f299a47911c2ab3710f534e52fea62a633c96806995da5d25be4b2/pyparsing-3.2.1.tar.gz", hash = "sha256:61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a", size = 1067694 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl", hash = "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1", size = 107716 },
 ]
 
 [[package]]
@@ -279,7 +402,9 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "dt-model" },
+    { name = "matplotlib" },
     { name = "numpy" },
+    { name = "pandas" },
     { name = "scipy" },
     { name = "sympy" },
 ]
@@ -294,7 +419,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dt-model", git = "https://github.com/fbk-most/dt-model?rev=main" },
+    { name = "matplotlib" },
     { name = "numpy" },
+    { name = "pandas" },
     { name = "scipy" },
     { name = "sympy" },
 ]

--- a/yakof/molveno/__init__.py
+++ b/yakof/molveno/__init__.py
@@ -1,0 +1,12 @@
+"""
+Molveno Model
+=============
+
+This package contains the baseline Molveno model, in two
+distinct implementations, each in its own module:
+
+- `orig`: is the original model using dt_model
+- `yakof`: is the same model, but implemented using yakof
+"""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/yakof/molveno/orig.py
+++ b/yakof/molveno/orig.py
@@ -1,0 +1,337 @@
+"""
+Original Molveno Model
+======================
+
+This is the original Molveno model, using the original `dt_model`
+as its underlying execution engine.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+# TODO(bassosimone): consider removing the more __main__-ish code
+# parts from this file and using them elsewhere.
+
+import math
+import random
+from scipy import stats
+import numpy as np
+
+from dt_model import (
+    UniformCategoricalContextVariable,
+    CategoricalContextVariable,
+    PresenceVariable,
+    Index,
+    Constraint,
+    Ensemble,
+    Model,
+)
+from sympy import Symbol, Eq, Piecewise
+
+import matplotlib.pyplot as plt
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import Normalize
+
+from presence_stats import (
+    season,
+    weather,
+    weekday,
+    tourist_presences_stats,
+    excursionist_presences_stats,
+)
+
+# MODEL DEFINITION
+
+# Context variables
+
+CV_weekday = UniformCategoricalContextVariable("weekday", [Symbol(v) for v in weekday])
+CV_season = CategoricalContextVariable(
+    "season", {Symbol(v): season[v] for v in season.keys()}
+)
+CV_weather = CategoricalContextVariable(
+    "weather", {Symbol(v): weather[v] for v in weather.keys()}
+)
+
+# Presence variables
+
+PV_tourists = PresenceVariable(
+    "tourists", [CV_weekday, CV_season, CV_weather], tourist_presences_stats
+)
+PV_excursionists = PresenceVariable(
+    "excursionists", [CV_weekday, CV_season, CV_weather], excursionist_presences_stats
+)
+
+# Capacity indexes
+
+I_C_parking = Index("parking capacity", stats.uniform(loc=350.0, scale=100.0))
+I_C_beach = Index("beach capacity", stats.uniform(loc=6000.0, scale=1000.0))
+I_C_accommodation = Index(
+    "accommodation capacity", stats.lognorm(s=0.125, loc=0.0, scale=5000.0)
+)
+I_C_food = Index("food service capacity", stats.triang(loc=3000.0, scale=1000.0, c=0.5))
+
+# Usage indexes
+
+I_U_tourists_parking = Index("tourist parking usage factor", 0.02)
+I_U_excursionists_parking = Index(
+    "excursionist parking usage factor",
+    Piecewise((0.55, Eq(CV_weather, Symbol("bad"))), (0.80, True)),
+    cvs=[CV_weather],
+)
+
+I_U_tourists_beach = Index(
+    "tourist beach usage factor",
+    Piecewise((0.25, Eq(CV_weather, Symbol("bad"))), (0.50, True)),
+    cvs=[CV_weather],
+)
+I_U_excursionists_beach = Index(
+    "excursionist beach usage factor",
+    Piecewise((0.35, Eq(CV_weather, Symbol("bad"))), (0.80, True)),
+    cvs=[CV_weather],
+)
+
+I_U_tourists_accommodation = Index("tourist accommodation usage factor", 0.90)
+
+I_U_tourists_food = Index("tourist food service usage factor", 0.20)
+I_U_excursionists_food = Index(
+    "excursionist food service usage factor",
+    Piecewise((0.80, Eq(CV_weather, Symbol("bad"))), (0.40, True)),
+    cvs=[CV_weather, CV_weekday],
+)
+
+# Conversion indexes
+
+I_Xa_tourists_per_vehicle = Index("tourists per vehicle allocation factor", 2.5)
+I_Xa_excursionists_per_vehicle = Index(
+    "excursionists per vehicle allocation factor", 2.5
+)
+I_Xo_tourists_parking = Index("tourists in parking rotation factor", 1.02)
+I_Xo_excursionists_parking = Index("excursionists in parking rotation factor", 3.5)
+
+I_Xo_tourists_beach = Index(
+    "tourists on beach rotation factor", stats.uniform(loc=1.0, scale=2.0)
+)
+I_Xo_excursionists_beach = Index("excursionists on beach rotation factor", 1.02)
+
+I_Xa_tourists_accommodation = Index(
+    "tourists per accommodation allocation factor", 1.05
+)
+
+I_Xa_visitors_food = Index("visitors in food service allocation factor", 0.9)
+I_Xo_visitors_food = Index("visitors in food service rotation factor", 2.0)
+
+# Presence indexes
+
+I_P_tourists_reduction_factor = Index("tourists reduction factor", 1.0)
+I_P_excursionists_reduction_factor = Index("excursionists reduction factor", 1.0)
+
+I_P_tourists_saturation_level = Index("tourists saturation level", 10000)
+I_P_excursionists_saturation_level = Index("excursionists saturation level", 10000)
+
+
+# Constraints
+# TODO: add names to constraints?
+
+C_parking = Constraint(
+    usage=PV_tourists
+    * I_U_tourists_parking
+    / (I_Xa_tourists_per_vehicle * I_Xo_tourists_parking)
+    + PV_excursionists
+    * I_U_excursionists_parking
+    / (I_Xa_excursionists_per_vehicle * I_Xo_excursionists_parking),
+    capacity=I_C_parking,
+)
+
+C_beach = Constraint(
+    usage=PV_tourists * I_U_tourists_beach / I_Xo_tourists_beach
+    + PV_excursionists * I_U_excursionists_beach / I_Xo_excursionists_beach,
+    capacity=I_C_beach,
+)
+
+# TODO: also capacity should be a formula
+# C_accommodation = Constraint(usage=PV_tourists * I_U_tourists_accommodation,
+#                              capacity=I_C_accommodation *  I_Xa_tourists_accommodation)
+
+C_accommodation = Constraint(
+    usage=PV_tourists * I_U_tourists_accommodation / I_Xa_tourists_accommodation,
+    capacity=I_C_accommodation,
+)
+
+# TODO: also capacity should be a formula
+# C_food = Constraint(usage=PV_tourists * I_U_tourists_food +
+#                              PV_excursionists * I_U_excursionists_food,
+#                     capacity=I_C_food * I_Xa_visitors_food * I_Xo_visitors_food)
+C_food = Constraint(
+    usage=(PV_tourists * I_U_tourists_food + PV_excursionists * I_U_excursionists_food)
+    / (I_Xa_visitors_food * I_Xo_visitors_food),
+    capacity=I_C_food,
+)
+
+
+# Models
+# TODO: what is the better process to create a model? (e.g., adding elements incrementally)
+
+# Base model
+M_Base = Model(
+    "base model",
+    [CV_weekday, CV_season, CV_weather],
+    [PV_tourists, PV_excursionists],
+    [
+        I_U_tourists_parking,
+        I_U_excursionists_parking,
+        I_U_tourists_beach,
+        I_U_excursionists_beach,
+        I_U_tourists_accommodation,
+        I_U_tourists_food,
+        I_U_excursionists_food,
+        I_Xa_tourists_per_vehicle,
+        I_Xa_excursionists_per_vehicle,
+        I_Xa_tourists_accommodation,
+        I_Xo_tourists_parking,
+        I_Xo_excursionists_parking,
+        I_Xo_tourists_beach,
+        I_Xo_excursionists_beach,
+        I_Xa_visitors_food,
+        I_Xo_visitors_food,
+        I_P_tourists_reduction_factor,
+        I_P_excursionists_reduction_factor,
+        I_P_tourists_saturation_level,
+        I_P_excursionists_saturation_level,
+    ],
+    [I_C_parking, I_C_beach, I_C_accommodation, I_C_food],
+    [C_parking, C_beach, C_accommodation, C_food],
+)
+
+# Larger park capacity model
+I_C_parking_larger = Index(
+    "larger parking capacity", stats.uniform(loc=550.0, scale=100.0)
+)
+
+M_MoreParking = M_Base.variation(
+    "larger parking model", change_capacities={I_C_parking: I_C_parking_larger}
+)
+
+# ANALYSIS SITUATIONS
+
+# Base situation
+S_Base = {}
+
+# Good weather situation
+S_Good_Weather = {CV_weather: [Symbol("good")]}
+
+# Bad weather situation
+S_Bad_Weather = {CV_weather: [Symbol("bad")]}
+
+# PLOTTING
+
+(t_max, e_max) = (10000, 10000)
+(t_sample, e_sample) = (100, 100)
+target_presence_samples = 200
+ensemble_size = 20  # TODO: make configurable; may it be a CV parameter?
+
+
+def scale(p, v):
+    return p * v
+
+
+def threshold(p, t):
+    return min(p, t) + 0.05 / (1 + np.exp(-(p - t)))
+
+
+def plot_scenario(ax, model, situation, title):
+    ensemble = Ensemble(model, situation, cv_ensemble_size=ensemble_size)
+    tt = np.linspace(0, t_max, t_sample + 1)
+    ee = np.linspace(0, e_max, e_sample + 1)
+    xx, yy = np.meshgrid(tt, ee)
+    zz = model.evaluate({PV_tourists: tt, PV_excursionists: ee}, ensemble)
+
+    sample_tourists = [
+        sample
+        for c in ensemble
+        for sample in PV_tourists.sample(
+            cvs=c[1], nr=max(1, round(c[0] * target_presence_samples))
+        )
+    ]
+    sample_excursionists = [
+        sample
+        for c in ensemble
+        for sample in PV_excursionists.sample(
+            cvs=c[1], nr=max(1, round(c[0] * target_presence_samples))
+        )
+    ]
+
+    # Presence Transformation function
+    # TODO: manage differently!
+    def presence_transformation(
+        presence, reduction_factor, saturation_level, sharpness=3
+    ):
+        tmp = presence * reduction_factor
+        return (
+            tmp
+            * saturation_level
+            / ((tmp**sharpness + saturation_level**sharpness) ** (1 / sharpness))
+        )
+
+    sample_tourists = [
+        presence_transformation(
+            presence,
+            model.get_index_mean_value(I_P_tourists_reduction_factor),
+            model.get_index_mean_value(I_P_tourists_saturation_level),
+        )
+        for presence in sample_tourists
+    ]
+    sample_excursionists = [
+        presence_transformation(
+            presence,
+            model.get_index_mean_value(I_P_excursionists_reduction_factor),
+            model.get_index_mean_value(I_P_excursionists_saturation_level),
+        )
+        for presence in sample_excursionists
+    ]
+
+    # TODO: move elsewhere, it cannot be computed this way...
+    area = model.compute_sustainable_area()
+    index = model.compute_sustainability_index(
+        list(zip(sample_tourists, sample_excursionists))
+    )
+    indexes = model.compute_sustainability_index_per_constraint(
+        list(zip(sample_tourists, sample_excursionists))
+    )
+    critical = min(indexes, key=indexes.get)
+    modals = model.compute_modal_line_per_constraint()
+
+    ax.pcolormesh(xx, yy, zz, cmap="coolwarm_r", vmin=0.0, vmax=1.0)
+    for modal in modals.values():
+        ax.plot(*modal, color="black", linewidth=2)
+    ax.scatter(
+        sample_excursionists, sample_tourists, color="gainsboro", edgecolors="black"
+    )
+    ax.set_title(
+        f"{title}\n"
+        + f"area = {area / 10e6:.2f} kp$^2$ - "
+        + f"Sustainability = {index * 100:.2f}%\n"
+        + f"Critical = {critical.capacity.name} ({indexes[critical] * 100:.2f}%)",
+        fontsize=12,
+    )
+    ax.set_xlim(left=0, right=t_max)
+    ax.set_ylim(bottom=0, top=e_max)
+
+    model.reset()
+
+
+import time
+
+start_time = time.time()
+
+fig, axs = plt.subplots(2, 3, figsize=(18, 10), layout="constrained")
+plot_scenario(axs[0, 0], M_Base, S_Base, "Base")
+plot_scenario(axs[0, 1], M_Base, S_Good_Weather, "Good weather")
+plot_scenario(axs[0, 2], M_Base, S_Bad_Weather, "Bad weather")
+plot_scenario(axs[1, 0], M_MoreParking, S_Base, "More parking ")
+plot_scenario(axs[1, 1], M_MoreParking, S_Good_Weather, "More parking - Good weather")
+plot_scenario(axs[1, 2], M_MoreParking, S_Bad_Weather, "More parking - Bad weather")
+fig.colorbar(mappable=ScalarMappable(Normalize(0, 1), cmap="coolwarm_r"), ax=axs)
+fig.supxlabel("Tourists", fontsize=18)
+fig.supylabel("Excursionists", fontsize=18)
+fig.show()
+
+print("--- %s seconds ---" % (time.time() - start_time))

--- a/yakof/molveno/presence_stats.py
+++ b/yakof/molveno/presence_stats.py
@@ -1,0 +1,124 @@
+"""
+Presence Stats
+==============
+
+This module contains the baseline presence statistics used
+by the original and yakof-based Molveno models.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pandas as pd
+
+season_stats = pd.DataFrame(
+    [
+        {
+            "cluster_name": "very high",
+            "freq_rel": 0.2065,
+            "mean_tourists": 4585.8421052631575,
+            "std_tourists": 600.7764663941985,
+            "mean_excursionists": 6001.631578947368,
+            "std_excursionists": 910.7123713839693,
+        },
+        {
+            "cluster_name": "high",
+            "freq_rel": 0.2609,
+            "mean_tourists": 4019.5416666666665,
+            "std_tourists": 425.7224018134318,
+            "mean_excursionists": 3653.0416666666665,
+            "std_excursionists": 790.854874784884,
+        },
+        {
+            "cluster_name": "mid",
+            "freq_rel": 0.2935,
+            "mean_tourists": 2915.1111111111113,
+            "std_tourists": 426.69213665965236,
+            "mean_excursionists": 2476.6296296296296,
+            "std_excursionists": 829.2709099957879,
+        },
+        {
+            "cluster_name": "low",
+            "freq_rel": 0.2391,
+            "mean_tourists": 1798.090909090909,
+            "std_tourists": 480.97192365250527,
+            "mean_excursionists": 1165.909090909091,
+            "std_excursionists": 480.7615891766995,
+        },
+    ]
+).set_index("cluster_name")
+
+weather_stats = pd.DataFrame(
+    [
+        [0.15, 140.30952381, 463.13601314, -773.23809524, 1187.05786413],
+        [0.20, 128.32142857, 319.20470369, 31.10714286, 824.51775728],
+        [0.65, 72.86263736, 406.09163233, 282.91208791, 839.91419686],
+    ],
+    columns=[
+        "freq_rel",
+        "mean_tourists",
+        "std_tourists",
+        "mean_excursionists",
+        "std_excursionists",
+    ],
+    index=["bad", "unsettled", "good"],
+)
+
+weekday_stats = pd.DataFrame(
+    [
+        [-362.65934066, 112.47000414, -391.15384615, 791.84158997],
+        [-265.34065934, 122.13648742, -352.27472527, 937.65181712],
+        [-147.92307692, 247.5534754, -465.62637363, 733.9652083],
+        [92.23076923, 233.81638923, -380.35164835, 779.58869239],
+        [678.05494505, 149.44551186, -232.91208791, 500.50732948],
+        [320.46938776, 204.41996226, 590.98979592, 797.28902804],
+        [-278.93406593, 193.01797188, 1240.27472527, 1149.59709071],
+    ],
+    columns=[
+        "mean_tourists",
+        "std_tourists",
+        "mean_excursionists",
+        "std_excursionists",
+    ],
+    index=[
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ],
+)
+
+season = {s: season_stats.loc[s, "freq_rel"] for s in season_stats.index}
+weather = {w: weather_stats.loc[w, "freq_rel"] for w in weather_stats.index}
+weekday = weekday_stats.index
+
+
+def tourist_presences_stats(weekday, season, weather):
+    # Season
+    mean = season_stats.loc[season, "mean_tourists"]
+    std2 = season_stats.loc[season, "std_tourists"] ** 2
+    # Weather
+    mean += weather_stats.loc[weather, "mean_tourists"]
+    std2 += weather_stats.loc[weather, "std_tourists"] ** 2
+    # Weekdays
+    mean += weekday_stats.loc[weekday, "mean_tourists"]
+    std2 += weekday_stats.loc[weekday, "std_tourists"] ** 2
+    # Finalize and return
+    return {"mean": mean, "std": std2 ** (1 / 2)}
+
+
+def excursionist_presences_stats(weekday, season, weather):
+    # Season
+    mean = season_stats.loc[season, "mean_excursionists"]
+    std2 = season_stats.loc[season, "std_excursionists"] ** 2
+    # Weather
+    mean += weather_stats.loc[weather, "mean_excursionists"]
+    std2 += weather_stats.loc[weather, "std_excursionists"] ** 2
+    # Weekdays
+    mean += weekday_stats.loc[weekday, "mean_excursionists"]
+    std2 += weekday_stats.loc[weekday, "std_excursionists"] ** 2
+    # Finalize and return
+    return {"mean": mean, "std": std2 ** (1 / 2)}


### PR DESCRIPTION
This commit adds the original Molveno model to the repository.

I have pulled this code from: https://github.com/fbk-most/dt-model/commit/efded93eee8956508faa265b3c5e071a48d11b23

The changes compared to the original code has been adding docstrings, SPDX license identifiers, other minor comments, and reformatting using black.

Moving forward, the general idea is to have here two versions of the model, one using yakof and the other using the original model, and to use them side by side.