### PR TITLE
fix(piecewise): handle default case w/o clauses

### DIFF
--- a/tests/sympyke/test_piecewise.py
+++ b/tests/sympyke/test_piecewise.py
@@ -126,3 +126,22 @@ def test_piecewise_with_constant_conditions():
     expected = np.array([40, 50, 60])
 
     assert np.array_equal(result, expected)
+
+
+def test_piecewise_only_default_case():
+    """Test when filtering clauses leaves only the default case."""
+    # Create piecewise where all non-default clauses come after a True condition
+    pw = Piecewise(
+        (1, True),    # This becomes the default case
+        (10, False),  # This gets filtered out
+    )
+
+    # Linearize
+    plan = linearize.forest(pw)
+    state = executor.State(values={})
+
+    # Evaluate
+    for node in plan:
+        executor.evaluate(state, node)
+
+    assert state.values[pw] == 1

--- a/tests/sympyke/test_piecewise.py
+++ b/tests/sympyke/test_piecewise.py
@@ -132,7 +132,7 @@ def test_piecewise_only_default_case():
     """Test when filtering clauses leaves only the default case."""
     # Create piecewise where all non-default clauses come after a True condition
     pw = Piecewise(
-        (1, True),    # This becomes the default case
+        (1, True),  # This becomes the default case
         (10, False),  # This gets filtered out
     )
 

--- a/yakof/sympyke/piecewise.py
+++ b/yakof/sympyke/piecewise.py
@@ -67,7 +67,11 @@ def _to_tensor(clauses: list[Clause]) -> graph.Node:
     if isinstance(default_value, graph.Scalar):
         default_value = graph.constant(default_value)
 
-    # 3. Prepare the reversed clauses adapting the types
+    # 3. If no clauses remain after removing the default, just return the default value
+    if len(clauses) <= 0:
+        return default_value
+
+    # 4. Prepare the reversed clauses adapting the types
     reversed: list[tuple[graph.Node, graph.Node]] = []
     for expr, cond in clauses:
         if isinstance(expr, graph.Scalar):
@@ -76,5 +80,5 @@ def _to_tensor(clauses: list[Clause]) -> graph.Node:
             cond = graph.constant(cond)
         reversed.append((cond, expr))
 
-    # 4. We're now all set call multi_clause_where
+    # 5. We're now all set call multi_clause_where
     return graph.multi_clause_where(reversed, default_value)


### PR DESCRIPTION
This diff ensures that, if we only a default case and no other clauses, we short-circuit to the default case.