### PR TITLE
fix(pyproject.toml): use precise dependency spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 name = "yakof"
 version = "0.1.0"
 description = "A technology demonstrator for sustainability modeling"
-# TODO(bassosimone): use ~=3.11.0 once https://github.com/fbk-most/dt-model/pull/10
-# has been merged and has relaxed the upstream constraints.
+# TODO(bassosimone): use ~=3.11.0 once https://github.com/fbk-most/dt-model/pull/10 lands
 requires-python = "==3.11.11"
 dependencies = [
     "dt_model",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,22 @@
 name = "yakof"
 version = "0.1.0"
 description = "A technology demonstrator for sustainability modeling"
+# TODO(bassosimone): use ~=3.11.0 once https://github.com/fbk-most/dt-model/pull/10
+# has been merged and has relaxed the upstream constraints.
 requires-python = "==3.11.11"
-dependencies = ["dt_model", "matplotlib", "numpy", "pandas", "scipy", "sympy"]
-license = "Apache-2.0"
+dependencies = [
+    "dt_model",
+    "matplotlib>=3.10.0",
+    "numpy>=2.2.0",
+    "pandas>=2.2.0",
+    "scipy>=1.15.0",
+    "sympy>=1.13.0",
+]
+license = { file = "LICENSE" }
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = ["black>=24.10.0", "pytest>=7.0.0", "pytest-cov>=4.0.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -419,11 +419,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dt-model", git = "https://github.com/fbk-most/dt-model?rev=main" },
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "scipy" },
-    { name = "sympy" },
+    { name = "matplotlib", specifier = ">=3.10.0" },
+    { name = "numpy", specifier = ">=2.2.0" },
+    { name = "pandas", specifier = ">=2.2.0" },
+    { name = "scipy", specifier = ">=1.15.0" },
+    { name = "sympy", specifier = ">=1.13.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Explicitly list the precise dependencies, as we did in https://github.com/fbk-most/dt-model/pull/10.

While there, try to sync this file with the `dt-model` file, by using the `setuptools` build backend rather than using `hatchling` (nothing should actually change, except more uniformity with the ~upstream repo).

Also, document the work to do to relax python version constraints once the corresponding `dt-model` PR -- https://github.com/fbk-most/dt-model/pull/10 -- has been merged.