### PR TITLE
fix: gtk-based matplotlib interactive plotting workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /coverage.xml
 __pycache__/
 /.venv
+/yakof.egg-info

--- a/README.md
+++ b/README.md
@@ -24,6 +24,35 @@ uv sync --dev
 uv pip install -e .
 ```
 
+## Interactive Plotting
+
+The Python version installed using `uv` is incompatible with matplotlib's
+`tkinter` *interactive plotting* as documented by [astral-sh/python-build-standalone#129](
+https://github.com/astral-sh/python-build-standalone/issues/129). The
+symptom is that, when calling `plt.show()` and using interactive plotting,
+you see the following warning and no figure is displayed:
+
+```
+UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
+```
+
+As a workaround, install the following system dependencies:
+
+```bash
+sudo apt install libgirepository-2.0-dev libcairo2-dev
+```
+
+and then run:
+
+```bash
+uv sync --dev --group gtk
+```
+
+These commands will enable plotting using the `matplotlib` Gtk backend.
+
+We will investigate alternative solutions to reduce the friction
+required to enable interactive plotting.
+
 ## Examples
 
 The `examples/` directory contains demonstrations of key features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = ["black>=24.10.0", "pytest>=7.0.0", "pytest-cov>=4.0.0"]
+gtk = ["pygobject"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = ["black>=24.10.0", "pytest>=7.0.0", "pytest-cov>=4.0.0"]
-gtk = ["pygobject"]
+gtk = ["pygobject>=3.52.0"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -290,6 +290,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pycairo"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/4a/42b26390181a7517718600fa7d98b951da20be982a50cd4afb3d46c2e603/pycairo-1.27.0.tar.gz", hash = "sha256:5cb21e7a00a2afcafea7f14390235be33497a2cce53a98a19389492a60628430", size = 661450 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/4b/d7887904e10673ff8d99aaa2e63f82b245441261ea29136254576ac1c730/pycairo-1.27.0-cp311-cp311-win32.whl", hash = "sha256:9a9b79f92a434dae65c34c830bb9abdbd92654195e73d52663cbe45af1ad14b2", size = 749772 },
+    { url = "https://files.pythonhosted.org/packages/90/d2/ae7c781ceaac315e7c80381f83dc779a591bde6892e3498c7b5f42ec6cb8/pycairo-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:d40a6d80b15dacb3672dc454df4bc4ab3988c6b3f36353b24a255dc59a1c8aea", size = 844101 },
+]
+
+[[package]]
+name = "pygobject"
+version = "3.52.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycairo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/36/fec530a313d3d48f12e112ac0a65ee3ccc87f385123a0493715609e8e99c/pygobject-3.52.3.tar.gz", hash = "sha256:00e427d291e957462a8fad659a9f9c8be776ff82a8b76bdf402f1eaeec086d82", size = 1235825 }
+
+[[package]]
 name = "pyparsing"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -415,6 +434,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
+gtk = [
+    { name = "pygobject" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -432,3 +454,4 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
 ]
+gtk = [{ name = "pygobject" }]

--- a/uv.lock
+++ b/uv.lock
@@ -454,4 +454,4 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
 ]
-gtk = [{ name = "pygobject" }]
+gtk = [{ name = "pygobject", specifier = ">=3.52.0" }]


### PR DESCRIPTION
We have the issue that we cannot use tkinter with the python version downloaded by `uv` as documented by https://github.com/astral-sh/python-build-standalone/issues/129, therefore, interactive plotting is not working as intended.

As a workaround, document and add support for using the `gtk` backend for `matplotlib`. This entails documenting the system dependencies to install on a typical debian system, and adding support for installing the gtk backend with `uv sync --dev --group gtk`, should this be needed.

TBH, I am not satisfied by this solution, since it adds friction that won't make researchers happy here. I'm considering suggesting to either using a container or recommending people to use [LinuxBrew](https://docs.brew.sh/Homebrew-on-Linux), which at least should install Python binaries that work as intended. (I do not fully understand *why* the binaries provided by `uv` do not include a dynamic `_tkinter` dependency and I do not know why `matplotlib` requires to check for `__file__`, which is optional, but anyway, here we are, with either nonworking-by-default interactive plotting or uncertainty regarding the Python version we're using.)

While there, ignore `/yakof.egg-info`, which I forgot to add in my previous pull request.