### PR TITLE
cleanup: remove gtk-interactive-plot workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,35 +24,6 @@ uv sync --dev
 uv pip install -e .
 ```
 
-## Interactive Plotting
-
-The Python version installed using `uv` is incompatible with matplotlib's
-`tkinter` *interactive plotting* as documented by [astral-sh/python-build-standalone#129](
-https://github.com/astral-sh/python-build-standalone/issues/129). The
-symptom is that, when calling `plt.show()` and using interactive plotting,
-you see the following warning and no figure is displayed:
-
-```
-UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
-```
-
-As a workaround, install the following system dependencies:
-
-```bash
-sudo apt install libgirepository-2.0-dev libcairo2-dev
-```
-
-and then run:
-
-```bash
-uv sync --dev --group gtk
-```
-
-These commands will enable plotting using the `matplotlib` Gtk backend.
-
-We will investigate alternative solutions to reduce the friction
-required to enable interactive plotting.
-
 ## Examples
 
 The `examples/` directory contains demonstrations of key features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
 ]
-gtk = ["pygobject>=3.52.0"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -533,29 +533,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycairo"
-version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/4a/42b26390181a7517718600fa7d98b951da20be982a50cd4afb3d46c2e603/pycairo-1.27.0.tar.gz", hash = "sha256:5cb21e7a00a2afcafea7f14390235be33497a2cce53a98a19389492a60628430", size = 661450 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/4b/d7887904e10673ff8d99aaa2e63f82b245441261ea29136254576ac1c730/pycairo-1.27.0-cp311-cp311-win32.whl", hash = "sha256:9a9b79f92a434dae65c34c830bb9abdbd92654195e73d52663cbe45af1ad14b2", size = 749772 },
-    { url = "https://files.pythonhosted.org/packages/90/d2/ae7c781ceaac315e7c80381f83dc779a591bde6892e3498c7b5f42ec6cb8/pycairo-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:d40a6d80b15dacb3672dc454df4bc4ab3988c6b3f36353b24a255dc59a1c8aea", size = 844101 },
-    { url = "https://files.pythonhosted.org/packages/1c/65/7664fe3d9928572b7804c651a99cfd6113338eee7436d5b25401c9382619/pycairo-1.27.0-cp312-cp312-win32.whl", hash = "sha256:e2239b9bb6c05edae5f3be97128e85147a155465e644f4d98ea0ceac7afc04ee", size = 750005 },
-    { url = "https://files.pythonhosted.org/packages/f4/bd/114597b9f79fbdb4eb0a4bf4aa54e70246d87f512a880e66a85c1e2ff407/pycairo-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:27cb4d3a80e3b9990af552818515a8e466e0317063a6e61585533f1a86f1b7d5", size = 844100 },
-    { url = "https://files.pythonhosted.org/packages/93/76/35d2feef50584cb00d2b4d2215337b0bc765508f8856735a41bfedcb4699/pycairo-1.27.0-cp313-cp313-win32.whl", hash = "sha256:01505c138a313df2469f812405963532fc2511fb9bca9bdc8e0ab94c55d1ced8", size = 750001 },
-    { url = "https://files.pythonhosted.org/packages/9c/e7/92d6e57deee53229bb8b3f7df6d02c503585be7bdd69cb9e54f34aab089b/pycairo-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:b0349d744c068b6644ae23da6ada111c8a8a7e323b56cbce3707cba5bdb474cc", size = 844102 },
-]
-
-[[package]]
-name = "pygobject"
-version = "3.52.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycairo" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/36/fec530a313d3d48f12e112ac0a65ee3ccc87f385123a0493715609e8e99c/pygobject-3.52.3.tar.gz", hash = "sha256:00e427d291e957462a8fad659a9f9c8be776ff82a8b76bdf402f1eaeec086d82", size = 1235825 }
-
-[[package]]
 name = "pyparsing"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -766,9 +743,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
-gtk = [
-    { name = "pygobject" },
-]
 
 [package.metadata]
 requires-dist = [
@@ -787,4 +761,3 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
 ]
-gtk = [{ name = "pygobject", specifier = ">=3.52.0" }]


### PR DESCRIPTION
This diff reverts most of https://github.com/bassosimone/yakof/pull/65, which isn't needed anymore since we have now landed a better fix at https://github.com/bassosimone/yakof/pull/66. Therefore, we can now develop with the system Python, which is most likely greater than 3.11.11, yet, we can still typecheck using 3.11.11.